### PR TITLE
Add database connection retry logic to entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,9 @@ COPY --from=builder /app/drizzle.config.ts ./drizzle.config.ts
 # Copy package.json for drizzle-kit to work
 COPY --from=builder /app/package.json ./package.json
 
+# Copy database wait script
+COPY wait-for-db.mjs /app/wait-for-db.mjs
+
 # Copy entrypoint script
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod +x /docker-entrypoint.sh

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,41 +1,24 @@
 #!/bin/sh
 set -e
 
-# Configuration
-MAX_RETRIES=10
-INITIAL_WAIT=2
-MAX_WAIT=30
+echo "📊 Database connection info:"
+echo "   DATABASE_URL: $DATABASE_URL"
 
+# Wait for database to be connectable
+echo ""
+node /app/wait-for-db.mjs || {
+  echo "❌ Database is not reachable"
+  exit 1
+}
+
+# Run migrations
+echo ""
 echo "🔄 Running database migrations..."
-echo "Using DATABASE_URL: $DATABASE_URL"
+node_modules/.bin/drizzle-kit migrate || {
+  echo "❌ Migration failed!"
+  exit 1
+}
 
-# Retry logic with exponential backoff
-retry_count=0
-wait_time=$INITIAL_WAIT
-
-while [ $retry_count -lt $MAX_RETRIES ]; do
-  if node_modules/.bin/drizzle-kit migrate; then
-    echo "✅ Migrations complete"
-    echo "🚀 Starting application..."
-    exec node --import ./.output/server/instrument.server.mjs .output/server/index.mjs
-  else
-    retry_count=$((retry_count + 1))
-
-    if [ $retry_count -ge $MAX_RETRIES ]; then
-      echo "❌ Migration failed after $MAX_RETRIES attempts!"
-      exit 1
-    fi
-
-    echo "⚠️  Migration attempt $retry_count failed. Retrying in ${wait_time}s..."
-    sleep $wait_time
-
-    # Exponential backoff with cap
-    wait_time=$((wait_time * 2))
-    if [ $wait_time -gt $MAX_WAIT ]; then
-      wait_time=$MAX_WAIT
-    fi
-  fi
-done
-
-echo "❌ Migration failed after $MAX_RETRIES attempts!"
-exit 1
+echo "✅ Migrations complete"
+echo "🚀 Starting application..."
+exec node --import ./.output/server/instrument.server.mjs .output/server/index.mjs

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,13 +1,41 @@
 #!/bin/sh
 set -e
 
+# Configuration
+MAX_RETRIES=10
+INITIAL_WAIT=2
+MAX_WAIT=30
+
 echo "🔄 Running database migrations..."
 echo "Using DATABASE_URL: $DATABASE_URL"
-node_modules/.bin/drizzle-kit migrate || {
-  echo "❌ Migration failed!"
-  exit 1
-}
 
-echo "✅ Migrations complete"
-echo "🚀 Starting application..."
-exec node --import ./.output/server/instrument.server.mjs .output/server/index.mjs
+# Retry logic with exponential backoff
+retry_count=0
+wait_time=$INITIAL_WAIT
+
+while [ $retry_count -lt $MAX_RETRIES ]; do
+  if node_modules/.bin/drizzle-kit migrate; then
+    echo "✅ Migrations complete"
+    echo "🚀 Starting application..."
+    exec node --import ./.output/server/instrument.server.mjs .output/server/index.mjs
+  else
+    retry_count=$((retry_count + 1))
+
+    if [ $retry_count -ge $MAX_RETRIES ]; then
+      echo "❌ Migration failed after $MAX_RETRIES attempts!"
+      exit 1
+    fi
+
+    echo "⚠️  Migration attempt $retry_count failed. Retrying in ${wait_time}s..."
+    sleep $wait_time
+
+    # Exponential backoff with cap
+    wait_time=$((wait_time * 2))
+    if [ $wait_time -gt $MAX_WAIT ]; then
+      wait_time=$MAX_WAIT
+    fi
+  fi
+done
+
+echo "❌ Migration failed after $MAX_RETRIES attempts!"
+exit 1

--- a/wait-for-db.mjs
+++ b/wait-for-db.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+import pg from 'pg';
+
+const MAX_RETRIES = 30;
+const RETRY_DELAY_MS = 2000;
+
+async function waitForDatabase() {
+	const databaseUrl = process.env.DATABASE_URL;
+
+	if (!databaseUrl) {
+		console.error('❌ DATABASE_URL environment variable is not set');
+		process.exit(1);
+	}
+
+	console.log('⏳ Waiting for database to be ready...');
+	console.log(`   Using: ${databaseUrl.replace(/:[^:@]+@/, ':****@')}`);
+
+	for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+		const client = new pg.Client({
+			connectionString: databaseUrl,
+			connectionTimeoutMillis: 5000,
+		});
+
+		try {
+			await client.connect();
+			await client.query('SELECT 1');
+			await client.end();
+
+			console.log(`✅ Database is ready! (attempt ${attempt}/${MAX_RETRIES})`);
+			process.exit(0);
+		} catch (error) {
+			await client.end().catch(() => {});
+
+			const isLastAttempt = attempt === MAX_RETRIES;
+
+			if (isLastAttempt) {
+				console.error(`❌ Failed to connect to database after ${MAX_RETRIES} attempts`);
+				console.error(`   Error: ${error.message}`);
+				process.exit(1);
+			}
+
+			console.log(`⚠️  Connection attempt ${attempt}/${MAX_RETRIES} failed: ${error.message}`);
+			console.log(`   Retrying in ${RETRY_DELAY_MS / 1000}s...`);
+
+			await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS));
+		}
+	}
+}
+
+waitForDatabase();


### PR DESCRIPTION
Fixes production issue where migrations fail with EAI_AGAIN DNS
resolution errors during startup. The app was trying to connect
before the database was fully ready.

Changes:
- Add retry mechanism with up to 10 attempts
- Implement exponential backoff (2s, 4s, 8s, 16s, capped at 30s)
- Total wait time of up to ~210 seconds before giving up
- Improves resilience in production environments like Dokploy

This handles DNS resolution delays and database startup timing issues.