### PR TITLE
Add Media page with thumbnail grid and navigation link

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,6 +4,7 @@ import {
 	ChevronRight,
 	Cookie,
 	Home,
+	Image,
 	Menu,
 	Network,
 	SquareFunction,
@@ -82,6 +83,19 @@ export default function Header() {
 					>
 						<Cookie size={20} />
 						<span className='font-medium'>Session Test</span>
+					</Link>
+
+					<Link
+						to='/media'
+						onClick={() => setIsOpen(false)}
+						className='flex items-center gap-3 p-3 rounded-lg hover:bg-gray-800 transition-colors mb-2'
+						activeProps={{
+							className:
+								'flex items-center gap-3 p-3 rounded-lg bg-cyan-600 hover:bg-cyan-700 transition-colors mb-2',
+						}}
+					>
+						<Image size={20} />
+						<span className='font-medium'>Media</span>
 					</Link>
 
 					{/* Demo Links Start */}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as MediaRouteImport } from './routes/media'
 import { Route as ItemsRouteImport } from './routes/items'
 import { Route as CookieTestRouteImport } from './routes/cookie-test'
 import { Route as IndexRouteImport } from './routes/index'
@@ -22,6 +23,11 @@ import { Route as DemoStartSsrSpaModeRouteImport } from './routes/demo/start.ssr
 import { Route as DemoStartSsrFullSsrRouteImport } from './routes/demo/start.ssr.full-ssr'
 import { Route as DemoStartSsrDataOnlyRouteImport } from './routes/demo/start.ssr.data-only'
 
+const MediaRoute = MediaRouteImport.update({
+  id: '/media',
+  path: '/media',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ItemsRoute = ItemsRouteImport.update({
   id: '/items',
   path: '/items',
@@ -87,6 +93,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/cookie-test': typeof CookieTestRoute
   '/items': typeof ItemsRoute
+  '/media': typeof MediaRoute
   '/demo/tanstack-query': typeof DemoTanstackQueryRoute
   '/demo/api/names': typeof DemoApiNamesRoute
   '/demo/api/tq-todos': typeof DemoApiTqTodosRoute
@@ -101,6 +108,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/cookie-test': typeof CookieTestRoute
   '/items': typeof ItemsRoute
+  '/media': typeof MediaRoute
   '/demo/tanstack-query': typeof DemoTanstackQueryRoute
   '/demo/api/names': typeof DemoApiNamesRoute
   '/demo/api/tq-todos': typeof DemoApiTqTodosRoute
@@ -116,6 +124,7 @@ export interface FileRoutesById {
   '/': typeof IndexRoute
   '/cookie-test': typeof CookieTestRoute
   '/items': typeof ItemsRoute
+  '/media': typeof MediaRoute
   '/demo/tanstack-query': typeof DemoTanstackQueryRoute
   '/demo/api/names': typeof DemoApiNamesRoute
   '/demo/api/tq-todos': typeof DemoApiTqTodosRoute
@@ -132,6 +141,7 @@ export interface FileRouteTypes {
     | '/'
     | '/cookie-test'
     | '/items'
+    | '/media'
     | '/demo/tanstack-query'
     | '/demo/api/names'
     | '/demo/api/tq-todos'
@@ -146,6 +156,7 @@ export interface FileRouteTypes {
     | '/'
     | '/cookie-test'
     | '/items'
+    | '/media'
     | '/demo/tanstack-query'
     | '/demo/api/names'
     | '/demo/api/tq-todos'
@@ -160,6 +171,7 @@ export interface FileRouteTypes {
     | '/'
     | '/cookie-test'
     | '/items'
+    | '/media'
     | '/demo/tanstack-query'
     | '/demo/api/names'
     | '/demo/api/tq-todos'
@@ -175,6 +187,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   CookieTestRoute: typeof CookieTestRoute
   ItemsRoute: typeof ItemsRoute
+  MediaRoute: typeof MediaRoute
   DemoTanstackQueryRoute: typeof DemoTanstackQueryRoute
   DemoApiNamesRoute: typeof DemoApiNamesRoute
   DemoApiTqTodosRoute: typeof DemoApiTqTodosRoute
@@ -188,6 +201,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/media': {
+      id: '/media'
+      path: '/media'
+      fullPath: '/media'
+      preLoaderRoute: typeof MediaRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/items': {
       id: '/items'
       path: '/items'
@@ -279,6 +299,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   CookieTestRoute: CookieTestRoute,
   ItemsRoute: ItemsRoute,
+  MediaRoute: MediaRoute,
   DemoTanstackQueryRoute: DemoTanstackQueryRoute,
   DemoApiNamesRoute: DemoApiNamesRoute,
   DemoApiTqTodosRoute: DemoApiTqTodosRoute,

--- a/src/routes/media.tsx
+++ b/src/routes/media.tsx
@@ -53,8 +53,11 @@ const getMediaItems = createServerFn({ method: 'GET' }).handler(async () => {
 			});
 		}
 
-		if (row.thumbnail.id) {
-			itemsMap.get(row.id)?.thumbnails.push(row.thumbnail);
+		if (row.thumbnail?.id) {
+			const item = itemsMap.get(row.id);
+			if (item && row.thumbnail) {
+				item.thumbnails.push(row.thumbnail);
+			}
 		}
 	}
 

--- a/src/routes/media.tsx
+++ b/src/routes/media.tsx
@@ -1,0 +1,127 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { createServerFn } from '@tanstack/react-start';
+import { desc, eq } from 'drizzle-orm';
+import { db } from '@/db';
+import { items, thumbnails } from '@/db/schema';
+
+const getMediaItems = createServerFn({ method: 'GET' }).handler(async () => {
+	const result = await db
+		.select({
+			id: items.id,
+			type: items.type,
+			private: items.private,
+			createdAt: items.createdAt,
+			thumbnail: {
+				id: thumbnails.id,
+				path: thumbnails.path,
+				width: thumbnails.width,
+				height: thumbnails.height,
+				type: thumbnails.type,
+			},
+		})
+		.from(items)
+		.leftJoin(thumbnails, eq(items.id, thumbnails.itemId))
+		.orderBy(desc(items.createdAt))
+		.limit(100);
+
+	// Group thumbnails by item
+	const itemsMap = new Map<
+		number,
+		{
+			id: number;
+			type: string;
+			private: boolean;
+			createdAt: Date | null;
+			thumbnails: Array<{
+				id: number;
+				path: string;
+				width: number;
+				height: number;
+				type: string;
+			}>;
+		}
+	>();
+
+	for (const row of result) {
+		if (!itemsMap.has(row.id)) {
+			itemsMap.set(row.id, {
+				id: row.id,
+				type: row.type,
+				private: row.private,
+				createdAt: row.createdAt,
+				thumbnails: [],
+			});
+		}
+
+		if (row.thumbnail.id) {
+			itemsMap.get(row.id)?.thumbnails.push(row.thumbnail);
+		}
+	}
+
+	return Array.from(itemsMap.values());
+});
+
+export const Route = createFileRoute('/media')({
+	component: MediaPage,
+	loader: () => getMediaItems(),
+});
+
+function MediaPage() {
+	const mediaItems = Route.useLoaderData();
+
+	return (
+		<div className='p-6'>
+			<h1 className='text-3xl font-bold mb-6'>Media</h1>
+
+			{mediaItems.length === 0 ? (
+				<div className='text-gray-500 text-center py-12'>
+					No media items found
+				</div>
+			) : (
+				<div className='grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4'>
+					{mediaItems.map((item) => {
+						// Get the smallest available thumbnail
+						const thumbnail = item.thumbnails.sort(
+							(a, b) => a.width - b.width,
+						)[0];
+
+						return (
+							<div
+								key={item.id}
+								className='relative aspect-square bg-gray-100 rounded-lg overflow-hidden hover:ring-2 hover:ring-blue-500 transition-all cursor-pointer group'
+							>
+								{thumbnail ? (
+									<img
+										src={thumbnail.path}
+										alt={`Media item ${item.id}`}
+										className='w-full h-full object-cover'
+									/>
+								) : (
+									<div className='w-full h-full flex items-center justify-center text-gray-400'>
+										<span className='text-sm'>No thumbnail</span>
+									</div>
+								)}
+
+								{/* Overlay info on hover */}
+								<div className='absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-50 transition-all flex items-end'>
+									<div className='p-2 text-white text-xs opacity-0 group-hover:opacity-100 transition-opacity'>
+										<div className='flex items-center gap-2'>
+											<span className='px-2 py-0.5 bg-blue-600 rounded text-xs'>
+												{item.type}
+											</span>
+											{item.private && (
+												<span className='px-2 py-0.5 bg-red-600 rounded text-xs'>
+													Private
+												</span>
+											)}
+										</div>
+									</div>
+								</div>
+							</div>
+						);
+					})}
+				</div>
+			)}
+		</div>
+	);
+}


### PR DESCRIPTION
- Create /media route with server function to fetch items and thumbnails
- Display media items in responsive grid layout (2-6 columns)
- Show thumbnail images with hover effects displaying item type and privacy status
- Add Media link to sidebar navigation with Image icon
- Auto-generated routeTree.gen.ts updated for new route