### PR TITLE
Fix VITE_CF_CDN_URL not being available at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM node:22-alpine AS builder
 
+# Build arguments for Vite (baked in at build time)
+ARG VITE_CF_CDN_URL
+ENV VITE_CF_CDN_URL=$VITE_CF_CDN_URL
+
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,13 +6,14 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        # VITE_ vars must be passed at build time (baked in by Vite)
+        VITE_CF_CDN_URL: ${VITE_CF_CDN_URL:-https://cdn.example.com}
     restart: always
     expose:
       - "3000"
     environment:
       DATABASE_URL: ${DATABASE_URL}
-      VITE_TEST: ${VITE_TEST:-prod-test}
-      VITE_CF_CDN_URL: ${VITE_CF_CDN_URL}
     logging:
       driver: json-file
       options:


### PR DESCRIPTION
VITE_ environment variables are baked in at build time by Vite, not at
runtime. Passing them via docker-compose environment section does not work
because the Docker image is already built by then.

Changes:
- Add VITE_CF_CDN_URL as ARG/ENV in Dockerfile builder stage
- Pass it as build arg in docker-compose.yml with fallback default
- Remove unused VITE_ vars from runtime environment section