### PR TITLE
Refactor ranked search filtering

### DIFF
--- a/src/lib/search/filterAndRankBySearch.test.ts
+++ b/src/lib/search/filterAndRankBySearch.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { filterAndRankBySearch, type RankedSearchFields } from './filterAndRankBySearch';
+
+type Item = {
+  description: string;
+  id: number;
+  name: string;
+  tags: string[];
+};
+
+const fields = [
+  (item) => item.name,
+  (item) => item.tags,
+  (item) => item.description,
+] satisfies RankedSearchFields<Item>;
+
+describe('filterAndRankBySearch', () => {
+  it('returns the original items for a blank search', () => {
+    const items: Item[] = [
+      { description: '', id: 1, name: 'First', tags: [] },
+      { description: '', id: 2, name: 'Second', tags: [] },
+    ];
+
+    expect(filterAndRankBySearch(items, '  ', fields)).toBe(items);
+  });
+
+  it('normalizes the search and ranks fields by priority', () => {
+    const items: Item[] = [
+      { description: 'Fresh APPLES', id: 1, name: 'Pie', tags: [] },
+      { description: '', id: 2, name: 'Crumble', tags: ['apple'] },
+      { description: '', id: 3, name: 'Apple tart', tags: [] },
+    ];
+
+    expect(filterAndRankBySearch(items, ' APPLE ', fields).map((item) => item.id)).toEqual([
+      3, 2, 1,
+    ]);
+  });
+
+  it('keeps source order within a rank and includes an item only at its highest rank', () => {
+    const items: Item[] = [
+      { description: 'soup', id: 1, name: 'First soup', tags: ['soup'] },
+      { description: '', id: 2, name: 'Second soup', tags: [] },
+      { description: '', id: 3, name: 'Other', tags: ['soup'] },
+      { description: '', id: 4, name: 'No match', tags: [] },
+    ];
+
+    expect(filterAndRankBySearch(items, 'soup', fields).map((item) => item.id)).toEqual([1, 2, 3]);
+    expect(items.map((item) => item.id)).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/src/lib/search/filterAndRankBySearch.ts
+++ b/src/lib/search/filterAndRankBySearch.ts
@@ -1,0 +1,38 @@
+type SearchableValue = string | readonly string[];
+
+export type RankedSearchFields<T> = readonly [
+  (item: T) => SearchableValue,
+  ...Array<(item: T) => SearchableValue>,
+];
+
+/**
+ * Filters by a case-insensitive substring and ranks matches by field priority,
+ * while preserving the original order within each priority.
+ */
+export function filterAndRankBySearch<T>(
+  items: readonly T[],
+  search: string,
+  fields: RankedSearchFields<T>,
+) {
+  const normalizedSearch = search.trim().toLowerCase();
+
+  if (!normalizedSearch) {
+    return items;
+  }
+
+  const rankedMatches = fields.map((getValue) => ({ getValue, matches: [] as T[] }));
+
+  for (const item of items) {
+    for (const rank of rankedMatches) {
+      const value = rank.getValue(item);
+      const values = typeof value === 'string' ? [value] : value;
+
+      if (values.some((candidate) => candidate.toLowerCase().includes(normalizedSearch))) {
+        rank.matches.push(item);
+        break;
+      }
+    }
+  }
+
+  return rankedMatches.flatMap((rank) => rank.matches);
+}

--- a/src/pages/diary/DiaryListPage.tsx
+++ b/src/pages/diary/DiaryListPage.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import { Card } from '@/components/card/Card';
 import { FloatingButton } from '@/components/floating-button/FloatingButton';
 import { TextInput } from '@/components/text-input/TextInput';
+import { filterAndRankBySearch, type RankedSearchFields } from '@/lib/search/filterAndRankBySearch';
 import { createDiaryEntry, type DiaryEntrySummary } from './diary.api';
 import css from './DiaryListPage.module.css';
 
@@ -13,12 +14,17 @@ type DiaryListPageProps = {
   entries: DiaryEntrySummary[];
 };
 
+const diarySearchFields = [
+  (entry) => entry.title,
+  (entry) => entry.markdown,
+] satisfies RankedSearchFields<DiaryEntrySummary>;
+
 export function DiaryListPage({ entries }: DiaryListPageProps) {
   const navigate = useNavigate();
   const router = useRouter();
   const [searchInputValue, setSearchInputValue] = useState('');
   const [search] = useThrottledValue(searchInputValue, { wait: 200 });
-  const visibleEntries = rankDiaryEntriesBySearch(entries, search);
+  const visibleEntries = filterAndRankBySearch(entries, search, diarySearchFields);
   const createMutation = useMutation({
     mutationFn: createDiaryEntry,
     onSuccess: async (entry) => {
@@ -109,28 +115,4 @@ function getLocalDate() {
   const now = new Date();
   const localNow = new Date(now.valueOf() - now.getTimezoneOffset() * 60_000);
   return localNow.toISOString().slice(0, 10);
-}
-
-/** Filters and sorts matching entries so title hits appear before entry-content hits. */
-function rankDiaryEntriesBySearch(entries: DiaryEntrySummary[], search: string) {
-  const normalizedSearch = search.trim().toLowerCase();
-
-  if (!normalizedSearch) {
-    return entries;
-  }
-
-  return entries
-    .flatMap((entry, index) => {
-      if (entry.title.toLowerCase().includes(normalizedSearch)) {
-        return [{ entry, index, rank: 0 }];
-      }
-
-      if (entry.markdown.toLowerCase().includes(normalizedSearch)) {
-        return [{ entry, index, rank: 1 }];
-      }
-
-      return [];
-    })
-    .sort((left, right) => left.rank - right.rank || left.index - right.index)
-    .map((result) => result.entry);
 }

--- a/src/pages/recipes/RecipesPage.tsx
+++ b/src/pages/recipes/RecipesPage.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import { Card } from '@/components/card/Card';
 import { FloatingButton } from '@/components/floating-button/FloatingButton';
 import { TextInput } from '@/components/text-input/TextInput';
+import { filterAndRankBySearch, type RankedSearchFields } from '@/lib/search/filterAndRankBySearch';
 import type { RecipeLibraryItem } from './recipes.api';
 import css from './RecipesPage.module.css';
 
@@ -13,10 +14,16 @@ type RecipesPageProps = {
   recipes: RecipeLibraryItem[];
 };
 
+const recipeSearchFields = [
+  (recipe) => recipe.name,
+  (recipe) => recipe.tags,
+  (recipe) => recipe.description,
+] satisfies RankedSearchFields<RecipeLibraryItem>;
+
 export function RecipesPage({ recipes }: RecipesPageProps) {
   const [searchInputValue, setSearchInputValue] = useState('');
   const [search] = useThrottledValue(searchInputValue, { wait: 200 });
-  const visibleRecipes = rankRecipesBySearch(recipes, search);
+  const visibleRecipes = filterAndRankBySearch(recipes, search, recipeSearchFields);
 
   return (
     <main className={css.page}>
@@ -103,42 +110,6 @@ export function RecipesPage({ recipes }: RecipesPageProps) {
       </FloatingButton>
     </main>
   );
-}
-
-/**
- * Filters and sorts matching recipes so name hits appear before tag hits, then description hits.
- */
-function rankRecipesBySearch(recipes: RecipeLibraryItem[], search: string) {
-  const normalizedSearch = search.trim().toLowerCase();
-
-  if (!normalizedSearch) {
-    return recipes;
-  }
-
-  return recipes
-    .flatMap((recipe, index) => {
-      const name = recipe.name.toLowerCase();
-      const hasMatchingTag = recipe.tags.some((tag) =>
-        tag.toLowerCase().includes(normalizedSearch),
-      );
-      const description = recipe.description.toLowerCase();
-
-      if (name.includes(normalizedSearch)) {
-        return [{ index, rank: 0, recipe }];
-      }
-
-      if (hasMatchingTag) {
-        return [{ index, rank: 1, recipe }];
-      }
-
-      if (description.includes(normalizedSearch)) {
-        return [{ index, rank: 2, recipe }];
-      }
-
-      return [];
-    })
-    .sort((left, right) => left.rank - right.rank || left.index - right.index)
-    .map((result) => result.recipe);
 }
 
 function getImageLayoutClass(imageCount: number) {


### PR DESCRIPTION
## Summary
- extract diary and recipe filtering/ranking into a typed reusable utility
- define page-specific searchable fields as ordered selectors
- preserve stable relevance ordering while supporting array fields such as recipe tags
- add focused tests for normalization, ranking, stability, and de-duplication

## Testing
- pnpm check:fix