### PR TITLE
Harden edge-case handling with regression tests

### DIFF
--- a/src/components/nav-menu/useNavMenuGroups.tsx
+++ b/src/components/nav-menu/useNavMenuGroups.tsx
@@ -2,6 +2,7 @@ import { Avatar } from '@base-ui/react/avatar';
 import { useNavigate } from '@tanstack/react-router';
 import { type ReactNode, useState } from 'react';
 import { signOut, useSession } from '@/lib/auth/client';
+import { takeGraphemes } from '@/lib/text/takeGraphemes';
 import css from './NavMenu.module.css';
 
 type MobileAccountLink = '/account' | '/login';
@@ -184,7 +185,7 @@ function getInitials(value: string) {
   const parts = value.trim().split(/\s+/).filter(Boolean);
 
   if (parts.length > 1) {
-    return `${parts[0]?.slice(0, 1) ?? ''}${parts.at(-1)?.slice(0, 1) ?? ''}`.toUpperCase();
+    return `${takeGraphemes(parts[0] ?? '', 1)}${takeGraphemes(parts.at(-1) ?? '', 1)}`.toUpperCase();
   }
 
   const compact = parts[0] ?? value.trim();
@@ -194,8 +195,8 @@ function getInitials(value: string) {
   }
 
   if (compact.includes('@')) {
-    return compact.slice(0, 2).toUpperCase();
+    return takeGraphemes(compact, 2).toUpperCase();
   }
 
-  return compact.slice(0, 2).toUpperCase();
+  return takeGraphemes(compact, 2).toUpperCase();
 }

--- a/src/components/upload-tile-grid/UploadTileGrid.tsx
+++ b/src/components/upload-tile-grid/UploadTileGrid.tsx
@@ -3,6 +3,12 @@ import { UploadIcon } from 'lucide-react';
 import { type ChangeEvent, type DragEvent, useId, useRef, useState } from 'react';
 import css from './UploadTileGrid.module.css';
 import { UploadTile } from './UploadTile';
+import {
+  areUploadFilesEqual,
+  formatUploadFileMeta,
+  getUploadFileKey,
+  mergeUploadFiles,
+} from './uploadFileSelection';
 
 type UploadTileGridProps = {
   className?: string;
@@ -24,7 +30,7 @@ export function UploadTileGrid({
   const [isDragActive, setIsDragActive] = useState(false);
 
   function addFiles(incomingFiles: Iterable<File>) {
-    const nextFiles = mergeFiles({
+    const nextFiles = mergeUploadFiles({
       currentFiles: files,
       incomingFiles: Array.from(incomingFiles),
       maxItemSize,
@@ -37,7 +43,7 @@ export function UploadTileGrid({
       );
     }
 
-    if (!areFilesEqual(files, nextFiles.files)) {
+    if (!areUploadFilesEqual(files, nextFiles.files)) {
       onFilesChange(nextFiles.files);
     }
   }
@@ -96,16 +102,14 @@ export function UploadTileGrid({
       onDrop={handleDrop}
     >
       {files.map((file) => {
-        const fileKey = getFileKey(file);
+        const fileKey = getUploadFileKey(file);
 
         return (
           <UploadTile
             file={file}
             key={fileKey}
-            metaLabel={formatFileMeta(file)}
-            onRemove={() =>
-              onFilesChange(files.filter((currentFile) => getFileKey(currentFile) !== fileKey))
-            }
+            metaLabel={formatUploadFileMeta(file)}
+            onRemove={() => onFilesChange(files.filter((currentFile) => currentFile !== file))}
           />
         );
       })}
@@ -135,81 +139,4 @@ function preventDefaultFileDrag(event: DragEvent<HTMLDivElement>) {
 
   event.preventDefault();
   return true;
-}
-
-function mergeFiles({
-  currentFiles,
-  incomingFiles,
-  maxItemSize,
-  maxItems,
-}: {
-  currentFiles: File[];
-  incomingFiles: File[];
-  maxItemSize: number;
-  maxItems: number;
-}) {
-  const nextFiles = new Map(currentFiles.map((file) => [getFileKey(file), file]));
-  let rejectedCount = 0;
-
-  for (const file of incomingFiles) {
-    if (!isImageFile(file)) {
-      continue;
-    }
-
-    const fileKey = getFileKey(file);
-
-    if (nextFiles.has(fileKey)) {
-      continue;
-    }
-
-    if (file.size > maxItemSize) {
-      rejectedCount += 1;
-      continue;
-    }
-
-    if (nextFiles.size >= maxItems) {
-      rejectedCount += 1;
-      continue;
-    }
-
-    nextFiles.set(fileKey, file);
-  }
-
-  return {
-    files: Array.from(nextFiles.values()),
-    rejectedCount,
-  };
-}
-
-function areFilesEqual(left: File[], right: File[]) {
-  if (left.length !== right.length) {
-    return false;
-  }
-
-  return left.every((file, index) => getFileKey(file) === getFileKey(right[index]!));
-}
-
-function getFileKey(file: File) {
-  return `${file.name}-${file.size}-${file.lastModified}`;
-}
-
-function isImageFile(file: File) {
-  return file.type.startsWith('image/') || /\.(avif|gif|heic|jpeg|jpg|png|webp)$/i.test(file.name);
-}
-
-function formatFileMeta(file: File) {
-  const extension = file.name.split('.').pop()?.toUpperCase() ?? 'IMG';
-  return `${extension} • ${formatBytes(file.size)}`;
-}
-
-function formatBytes(bytes: number) {
-  if (bytes < 1024) {
-    return `${bytes} B`;
-  }
-
-  if (bytes < 1024 * 1024) {
-    return `${(bytes / 1024).toFixed(1)} KB`;
-  }
-
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }

--- a/src/components/upload-tile-grid/uploadFileSelection.test.ts
+++ b/src/components/upload-tile-grid/uploadFileSelection.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import {
+  areUploadFilesEqual,
+  formatUploadFileMeta,
+  getUploadFileKey,
+  isUploadImageFile,
+  mergeUploadFiles,
+} from './uploadFileSelection';
+
+function imageFile(contents: string, name = 'photo.png', lastModified = 1) {
+  return new File([contents], name, { lastModified, type: 'image/png' });
+}
+
+describe('upload file selection', () => {
+  it('retains distinct files with colliding browser metadata and removes by object identity', () => {
+    const first = imageFile('a');
+    const second = imageFile('b');
+    const result = mergeUploadFiles({
+      currentFiles: [first],
+      incomingFiles: [second],
+      maxItemSize: 10,
+      maxItems: 2,
+    });
+
+    expect(result).toEqual({ files: [first, second], rejectedCount: 0 });
+    expect(getUploadFileKey(first)).not.toBe(getUploadFileKey(second));
+    expect(result.files.filter((file) => file !== first)).toEqual([second]);
+  });
+
+  it('deduplicates only repeated references and preserves stable keys', () => {
+    const file = imageFile('a');
+    const key = getUploadFileKey(file);
+    const result = mergeUploadFiles({
+      currentFiles: [file],
+      incomingFiles: [file],
+      maxItemSize: 10,
+      maxItems: 2,
+    });
+
+    expect(result).toEqual({ files: [file], rejectedCount: 0 });
+    expect(getUploadFileKey(file)).toBe(key);
+    expect(areUploadFilesEqual(result.files, [file])).toBe(true);
+    expect(areUploadFilesEqual(result.files, [imageFile('a')])).toBe(false);
+  });
+
+  it('accepts exact limits and reports files exceeding size or count', () => {
+    const first = imageFile('a');
+    const exactSize = imageFile('12');
+    const oversized = imageFile('123');
+    const result = mergeUploadFiles({
+      currentFiles: [first],
+      incomingFiles: [exactSize, oversized],
+      maxItemSize: 2,
+      maxItems: 2,
+    });
+
+    expect(result).toEqual({ files: [first, exactSize], rejectedCount: 1 });
+  });
+
+  it('uses the same MIME-based image policy as the server', () => {
+    expect(isUploadImageFile(new File(['x'], 'photo.jpg', { type: '' }))).toBe(false);
+    expect(isUploadImageFile(new File(['x'], 'photo', { type: 'image/jpeg' }))).toBe(true);
+    expect(isUploadImageFile(new File(['x'], 'photo.jpg', { type: 'text/plain' }))).toBe(false);
+  });
+
+  it.each([
+    [new File(['x'], 'photo', { type: 'image/png' }), 'PNG • 1 B'],
+    [new File(['x'], '.hidden', { type: 'image/jpeg' }), 'JPEG • 1 B'],
+    [new File(['x'], 'photo.', { type: 'image/webp' }), 'WEBP • 1 B'],
+    [new File([new Uint8Array(1024)], 'photo.avif', { type: 'image/avif' }), 'AVIF • 1.0 KB'],
+  ])('formats useful metadata for %s', (file, expected) => {
+    expect(formatUploadFileMeta(file)).toBe(expected);
+  });
+});

--- a/src/components/upload-tile-grid/uploadFileSelection.ts
+++ b/src/components/upload-tile-grid/uploadFileSelection.ts
@@ -1,0 +1,78 @@
+const fileIds = new WeakMap<File, number>();
+let nextFileId = 1;
+
+/** Adds valid files without conflating distinct files that share browser metadata. */
+export function mergeUploadFiles({
+  currentFiles,
+  incomingFiles,
+  maxItemSize,
+  maxItems,
+}: {
+  currentFiles: File[];
+  incomingFiles: File[];
+  maxItemSize: number;
+  maxItems: number;
+}) {
+  const files = currentFiles.filter((file, index) => currentFiles.indexOf(file) === index);
+  let rejectedCount = 0;
+
+  for (const file of incomingFiles) {
+    if (!isUploadImageFile(file) || files.includes(file)) {
+      continue;
+    }
+
+    if (file.size > maxItemSize || files.length >= maxItems) {
+      rejectedCount += 1;
+      continue;
+    }
+
+    files.push(file);
+  }
+
+  return { files, rejectedCount };
+}
+
+export function areUploadFilesEqual(left: File[], right: File[]) {
+  return left.length === right.length && left.every((file, index) => file === right[index]);
+}
+
+export function getUploadFileKey(file: File) {
+  let id = fileIds.get(file);
+
+  if (id === undefined) {
+    id = nextFileId;
+    nextFileId += 1;
+    fileIds.set(file, id);
+  }
+
+  return `upload-${id}`;
+}
+
+export function isUploadImageFile(file: File) {
+  return file.type.startsWith('image/');
+}
+
+export function formatUploadFileMeta(file: File) {
+  const lastDotIndex = file.name.lastIndexOf('.');
+  const fileExtension =
+    lastDotIndex > 0 && lastDotIndex < file.name.length - 1
+      ? file.name.slice(lastDotIndex + 1)
+      : '';
+  const mimeExtension = file.type.startsWith('image/')
+    ? (file.type.slice('image/'.length).split('+')[0] ?? '')
+    : '';
+  const extension = (fileExtension || mimeExtension || 'IMG').toUpperCase();
+  return `${extension} • ${formatBytes(file.size)}`;
+}
+
+function formatBytes(bytes: number) {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/src/lib/async/createSequentialTaskQueue.test.ts
+++ b/src/lib/async/createSequentialTaskQueue.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSequentialTaskQueue } from './createSequentialTaskQueue';
+
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+}
+
+describe('createSequentialTaskQueue', () => {
+  it('does not start a newer save until the older save has settled', async () => {
+    const first = deferred();
+    const second = deferred();
+    const task = vi
+      .fn<(value: string) => Promise<void>>()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const enqueue = createSequentialTaskQueue(task);
+
+    const firstResult = enqueue('older');
+    const secondResult = enqueue('newer');
+    await Promise.resolve();
+    expect(task).toHaveBeenCalledTimes(1);
+    expect(task).toHaveBeenLastCalledWith('older');
+
+    first.resolve();
+    await firstResult;
+    await Promise.resolve();
+    expect(task).toHaveBeenCalledTimes(2);
+    expect(task).toHaveBeenLastCalledWith('newer');
+
+    second.resolve();
+    await secondResult;
+  });
+
+  it('continues with the latest work after an earlier failure', async () => {
+    const error = new Error('save failed');
+    const first = deferred();
+    const task = vi
+      .fn<(value: string) => Promise<void>>()
+      .mockReturnValueOnce(first.promise)
+      .mockResolvedValueOnce(undefined);
+    const enqueue = createSequentialTaskQueue(task);
+
+    const olderResult = enqueue('older');
+    const newerResult = enqueue('newer');
+    await Promise.resolve();
+    expect(task).toHaveBeenCalledTimes(1);
+
+    first.reject(error);
+    await expect(olderResult).rejects.toBe(error);
+    await expect(newerResult).resolves.toBeUndefined();
+    expect(task).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/async/createSequentialTaskQueue.ts
+++ b/src/lib/async/createSequentialTaskQueue.ts
@@ -1,0 +1,13 @@
+/** Serializes async work so an older task can never finish after a newer task. */
+export function createSequentialTaskQueue<Input>(task: (input: Input) => unknown) {
+  let tail = Promise.resolve<unknown>(undefined);
+
+  return (input: Input) => {
+    const result = tail.then(() => task(input));
+    tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+}

--- a/src/lib/env/server.test.ts
+++ b/src/lib/env/server.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getServerEnv } from './server';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+function stubValidRequiredEnv() {
+  vi.stubEnv('DATABASE_URL', 'postgresql://postgres:postgres@localhost:5432/veles_dev');
+  vi.stubEnv('BETTER_AUTH_SECRET', 'abcdefghijklmnopqrstuvwxyz123456');
+}
+
+describe('getServerEnv', () => {
+  it.each(['DATABASE_URL', 'BETTER_AUTH_SECRET'] as const)(
+    'rejects missing, empty, and whitespace-only %s',
+    (key) => {
+      for (const value of [undefined, '', '   ']) {
+        stubValidRequiredEnv();
+        vi.stubEnv(key, value);
+        expect(() => getServerEnv()).toThrow(`Missing required environment variable: ${key}`);
+      }
+    },
+  );
+
+  it('enforces the authentication secret length boundary without leaking its value', () => {
+    stubValidRequiredEnv();
+    const weakSecret = 's'.repeat(31);
+    vi.stubEnv('BETTER_AUTH_SECRET', weakSecret);
+
+    expect(() => getServerEnv()).toThrow('BETTER_AUTH_SECRET must be at least 32 characters');
+    try {
+      getServerEnv();
+    } catch (error) {
+      expect(String(error)).not.toContain(weakSecret);
+    }
+
+    vi.stubEnv('BETTER_AUTH_SECRET', 's'.repeat(32));
+    expect(getServerEnv().betterAuthSecret).toBe('s'.repeat(32));
+  });
+
+  it('uses explicit values and documented optional fallbacks', () => {
+    stubValidRequiredEnv();
+    vi.stubEnv('VITE_APP_URL', '');
+    vi.stubEnv('VITE_CF_CDN_URL', '');
+    expect(getServerEnv()).toMatchObject({
+      appUrl: 'http://localhost:3000',
+      cdnUrl: '',
+    });
+
+    vi.stubEnv('VITE_APP_URL', 'https://app.example.com');
+    vi.stubEnv('VITE_CF_CDN_URL', 'https://cdn.example.com');
+    expect(getServerEnv()).toMatchObject({
+      appUrl: 'https://app.example.com',
+      cdnUrl: 'https://cdn.example.com',
+    });
+  });
+});

--- a/src/lib/env/server.ts
+++ b/src/lib/env/server.ts
@@ -2,9 +2,13 @@ const requiredServerEnv = ['DATABASE_URL', 'BETTER_AUTH_SECRET'] as const;
 
 export function getServerEnv() {
   for (const key of requiredServerEnv) {
-    if (!process.env[key]) {
+    if (!process.env[key]?.trim()) {
       throw new Error(`Missing required environment variable: ${key}`);
     }
+  }
+
+  if (process.env.BETTER_AUTH_SECRET!.length < 32) {
+    throw new Error('BETTER_AUTH_SECRET must be at least 32 characters');
   }
 
   return {

--- a/src/lib/hooks/useAutoSaveState.ts
+++ b/src/lib/hooks/useAutoSaveState.ts
@@ -1,5 +1,6 @@
 import { useDebouncer } from '@tanstack/react-pacer';
 import { useEffect, useRef, useState, type DependencyList, type SetStateAction } from 'react';
+import { createSequentialTaskQueue } from '@/lib/async/createSequentialTaskQueue';
 
 type UseAutoSaveStateOptions = {
   debounceMs: number;
@@ -14,10 +15,19 @@ export function useAutoSaveState<State>(
 ) {
   const [state, setState] = useState(initialState);
   const latestStateRef = useRef(state);
+  const saveCallbackRef = useRef(onDebouncedSave);
+  saveCallbackRef.current = onDebouncedSave;
+  const saveQueueRef = useRef<ReturnType<typeof createSequentialTaskQueue<State>> | null>(null);
+
+  if (saveQueueRef.current === null) {
+    saveQueueRef.current = createSequentialTaskQueue((stateToSave: State) =>
+      saveCallbackRef.current(stateToSave),
+    );
+  }
 
   const saveDebouncer = useDebouncer(
     (stateToSave: State) => {
-      onDebouncedSave(stateToSave);
+      void saveQueueRef.current?.(stateToSave).catch(() => undefined);
     },
     {
       onUnmount: (debouncer) => debouncer.flush(),

--- a/src/lib/invariant.test.ts
+++ b/src/lib/invariant.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest';
+import { invariant } from './invariant';
+
+describe('invariant', () => {
+  it.each([false, 0, '', Number.NaN])('accepts non-nullish value %j', (value) => {
+    expect(() => invariant(value, 'unexpected')).not.toThrow();
+  });
+
+  it.each([null, undefined])('throws the supplied message for %s', (value) => {
+    expect(() => invariant(value, 'missing')).toThrow('missing');
+  });
+
+  it('delegates violations to the supplied callback', () => {
+    const expected = new RangeError('outside range');
+    const onViolation = vi.fn(() => {
+      throw expected;
+    });
+
+    expect(() => invariant(null, onViolation)).toThrow(expected);
+    expect(onViolation).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lib/search/filterAndRankBySearch.test.ts
+++ b/src/lib/search/filterAndRankBySearch.test.ts
@@ -47,4 +47,17 @@ describe('filterAndRankBySearch', () => {
     expect(filterAndRankBySearch(items, 'soup', fields).map((item) => item.id)).toEqual([1, 2, 3]);
     expect(items.map((item) => item.id)).toEqual([1, 2, 3, 4]);
   });
+
+  it('matches canonically equivalent Unicode without mutating candidate fields', () => {
+    const tags = ['Cafe\u0301'];
+    const items: Item[] = [{ description: '', id: 1, name: 'Other', tags }];
+
+    expect(filterAndRankBySearch(items, 'Café', fields).map((item) => item.id)).toEqual([1]);
+    expect(tags).toEqual(['Cafe\u0301']);
+  });
+
+  it('returns no items when no field matches', () => {
+    const items: Item[] = [{ description: '', id: 1, name: 'Pie', tags: [] }];
+    expect(filterAndRankBySearch(items, 'soup', fields)).toEqual([]);
+  });
 });

--- a/src/lib/search/filterAndRankBySearch.ts
+++ b/src/lib/search/filterAndRankBySearch.ts
@@ -14,7 +14,7 @@ export function filterAndRankBySearch<T>(
   search: string,
   fields: RankedSearchFields<T>,
 ) {
-  const normalizedSearch = search.trim().toLowerCase();
+  const normalizedSearch = normalizeSearchValue(search.trim());
 
   if (!normalizedSearch) {
     return items;
@@ -27,7 +27,7 @@ export function filterAndRankBySearch<T>(
       const value = rank.getValue(item);
       const values = typeof value === 'string' ? [value] : value;
 
-      if (values.some((candidate) => candidate.toLowerCase().includes(normalizedSearch))) {
+      if (values.some((candidate) => normalizeSearchValue(candidate).includes(normalizedSearch))) {
         rank.matches.push(item);
         break;
       }
@@ -35,4 +35,8 @@ export function filterAndRankBySearch<T>(
   }
 
   return rankedMatches.flatMap((rank) => rank.matches);
+}
+
+function normalizeSearchValue(value: string) {
+  return value.normalize('NFC').toLowerCase();
 }

--- a/src/lib/storage/config.test.ts
+++ b/src/lib/storage/config.test.ts
@@ -1,13 +1,41 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getStorageConfig, storagePathToUrl } from './config';
+
+beforeEach(() => {
+  vi.stubEnv('DATABASE_URL', 'postgresql://postgres:postgres@localhost:5432/veles_dev');
+  vi.stubEnv('BETTER_AUTH_SECRET', 'abcdefghijklmnopqrstuvwxyz123456');
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 describe('storagePathToUrl', () => {
-  it('joins public url and object path', async () => {
-    vi.stubEnv('DATABASE_URL', 'postgresql://postgres:postgres@localhost:5432/veles_dev');
-    vi.stubEnv('BETTER_AUTH_SECRET', 'abcdefghijklmnopqrstuvwxyz123456');
+  it('joins public URL and object path with exactly one slash', () => {
     vi.stubEnv('R2_PUBLIC_URL', 'https://cdn.example.com');
-
-    const { storagePathToUrl } = await import('./config');
-
     expect(storagePathToUrl('/folder/file.png')).toBe('https://cdn.example.com/folder/file.png');
+
+    vi.stubEnv('R2_PUBLIC_URL', 'https://cdn.example.com///');
+    expect(storagePathToUrl('///folder/file.png')).toBe('https://cdn.example.com/folder/file.png');
+  });
+
+  it('returns null when either side of the URL is unavailable', () => {
+    vi.stubEnv('R2_PUBLIC_URL', '');
+    vi.stubEnv('VITE_CF_CDN_URL', '');
+    expect(storagePathToUrl('folder/file.png')).toBeNull();
+
+    vi.stubEnv('R2_PUBLIC_URL', 'https://cdn.example.com');
+    expect(storagePathToUrl(null)).toBeNull();
+    expect(storagePathToUrl(undefined)).toBeNull();
+    expect(storagePathToUrl('')).toBeNull();
+  });
+
+  it('prefers an explicit R2 public URL over the CDN fallback', () => {
+    vi.stubEnv('R2_PUBLIC_URL', 'https://r2.example.com');
+    vi.stubEnv('VITE_CF_CDN_URL', 'https://fallback.example.com');
+    expect(getStorageConfig().publicUrl).toBe('https://r2.example.com');
+
+    vi.stubEnv('R2_PUBLIC_URL', '');
+    expect(getStorageConfig().publicUrl).toBe('https://fallback.example.com');
   });
 });

--- a/src/lib/storage/config.ts
+++ b/src/lib/storage/config.ts
@@ -19,5 +19,5 @@ export function storagePathToUrl(path: string | null | undefined) {
     return null;
   }
 
-  return `${publicUrl.replace(/\/$/, '')}/${path.replace(/^\//, '')}`;
+  return `${publicUrl.replace(/\/+$/, '')}/${path.replace(/^\/+/, '')}`;
 }

--- a/src/lib/text/takeGraphemes.test.ts
+++ b/src/lib/text/takeGraphemes.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { takeGraphemes } from './takeGraphemes';
+
+describe('takeGraphemes', () => {
+  it.each([
+    ['abc', 2, 'ab'],
+    ['😀b', 1, '😀'],
+    ['e\u0301clair', 1, 'e\u0301'],
+    ['👨‍👩‍👧‍👦 family', 1, '👨‍👩‍👧‍👦'],
+    ['abc', 0, ''],
+    ['abc', -1, ''],
+    ['abc', Number.NaN, ''],
+    ['abc', Number.POSITIVE_INFINITY, ''],
+  ])('takes complete graphemes from %j at boundary %s', (value, maximum, expected) => {
+    expect(takeGraphemes(value, maximum)).toBe(expected);
+    expect(takeGraphemes(value, maximum)).not.toContain('\uFFFD');
+  });
+});

--- a/src/lib/text/takeGraphemes.ts
+++ b/src/lib/text/takeGraphemes.ts
@@ -1,0 +1,20 @@
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+
+/** Truncates visible text without splitting surrogate pairs or combining sequences. */
+export function takeGraphemes(value: string, maximum: number) {
+  const graphemeCount = Number.isFinite(maximum) ? Math.max(0, Math.floor(maximum)) : 0;
+  const segments = graphemeSegmenter.segment(value);
+  let result = '';
+  let count = 0;
+
+  for (const segment of segments) {
+    if (count >= graphemeCount) {
+      break;
+    }
+
+    result += segment.segment;
+    count += 1;
+  }
+
+  return result;
+}

--- a/src/pages/diary/DiaryEntryPage.tsx
+++ b/src/pages/diary/DiaryEntryPage.tsx
@@ -38,7 +38,7 @@ export function DiaryEntryPage({ entry, focusTitle = false }: DiaryEntryPageProp
       markdown: entry.markdown,
       title: entry.title,
     },
-    (nextDraft) => saveMutation.mutate({ data: nextDraft }),
+    (nextDraft) => saveMutation.mutateAsync({ data: nextDraft }),
     {
       debounceMs: 400,
       deps: [entry.entryDate, entry.id, entry.markdown, entry.title],

--- a/src/pages/diary/diary.api.ts
+++ b/src/pages/diary/diary.api.ts
@@ -8,6 +8,7 @@ import { diaryEntries } from '@/db/schema';
 import { requireSession } from '@/lib/auth/getSession';
 import { invariant } from '@/lib/invariant';
 import { logMiddleware } from '@/lib/middleware/logMiddleware';
+import { diaryEntryDateType } from './diaryEntryValidation';
 
 export type DiaryEntrySummary = {
   entryDate: string;
@@ -30,13 +31,12 @@ export const getDiaryEntries = createServerFn({ method: 'GET' })
       })
       .from(diaryEntries)
       .where(eq(diaryEntries.userId, session.user.id))
-      .orderBy(desc(diaryEntries.entryDate), desc(diaryEntries.createdAt));
+      .orderBy(desc(diaryEntries.entryDate), desc(diaryEntries.createdAt), desc(diaryEntries.id));
 
     return entries;
   });
 
 const idType = type({ id: 'string.uuid' });
-const diaryEntryDateType = type('string.date');
 const createDiaryEntryInputType = type({ entryDate: diaryEntryDateType });
 const updateDiaryEntryInputType = type({
   entryDate: diaryEntryDateType,

--- a/src/pages/diary/diaryEntryValidation.test.ts
+++ b/src/pages/diary/diaryEntryValidation.test.ts
@@ -1,0 +1,34 @@
+import { type } from 'arktype';
+import { describe, expect, it } from 'vitest';
+import { diaryEntryDateType, isCalendarDate } from './diaryEntryValidation';
+
+describe('diary entry date validation', () => {
+  it.each(['0001-01-01', '2000-02-29', '2024-02-29', '9999-12-31'])(
+    'accepts real canonical date %s',
+    (value) => {
+      expect(isCalendarDate(value)).toBe(true);
+      expect(diaryEntryDateType(value)).not.toBeInstanceOf(type.errors);
+    },
+  );
+
+  it.each([
+    '0000-01-01',
+    '1900-02-29',
+    '2023-02-29',
+    '2024-02-30',
+    '2024-04-31',
+    '2024-00-01',
+    '2024-13-01',
+    '2024-01-00',
+    '2024-01-32',
+    '2024-1-01',
+    '2024-01-1',
+    '2024-01-01T00:00:00Z',
+    ' 2024-01-01',
+    '0',
+    '',
+  ])('rejects malformed or impossible date %j', (value) => {
+    expect(isCalendarDate(value)).toBe(false);
+    expect(diaryEntryDateType(value)).toBeInstanceOf(type.errors);
+  });
+});

--- a/src/pages/diary/diaryEntryValidation.ts
+++ b/src/pages/diary/diaryEntryValidation.ts
@@ -1,0 +1,31 @@
+import { type } from 'arktype';
+
+export const diaryEntryDateType = type('string').narrow(
+  (value, context) =>
+    isCalendarDate(value) || context.mustBe('a valid calendar date in YYYY-MM-DD format'),
+);
+
+/** Validates a canonical Gregorian calendar date without JavaScript date coercion. */
+export function isCalendarDate(value: string) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+
+  if (!match) {
+    return false;
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+
+  if (year === 0 || month < 1 || month > 12 || day < 1) {
+    return false;
+  }
+
+  const daysInMonth = [31, isLeapYear(year) ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+  return day <= daysInMonth[month - 1]!;
+}
+
+function isLeapYear(year: number) {
+  return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+}

--- a/src/pages/recipes/AddRecipePage.tsx
+++ b/src/pages/recipes/AddRecipePage.tsx
@@ -10,10 +10,7 @@ import { TextareaInput } from '@/components/textarea-input/TextareaInput';
 import { TextInput } from '@/components/text-input/TextInput';
 import { UploadTileGrid } from '@/components/upload-tile-grid/UploadTileGrid';
 import css from './AddRecipePage.module.css';
-import {
-  RECIPE_UPLOAD_MAX_PHOTO_BYTES,
-  RECIPE_UPLOAD_MAX_PHOTO_COUNT,
-} from '@/routes/api/recipes/upload';
+import { RECIPE_UPLOAD_MAX_PHOTO_BYTES, RECIPE_UPLOAD_MAX_PHOTO_COUNT } from './recipeUploadInput';
 
 type AddRecipeDraft = {
   carbs: number | null;

--- a/src/pages/recipes/RecipeImgSlider.tsx
+++ b/src/pages/recipes/RecipeImgSlider.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
 import type { RecipeLibraryItem } from './recipes.api';
+import { getValidRecipeImageIndex } from './recipeImageIndex';
 import css from './RecipeViewPage.module.css';
 
 type RecipeImgSliderProps = {
@@ -8,16 +9,17 @@ type RecipeImgSliderProps = {
 };
 
 export function RecipeImgSlider({ images }: RecipeImgSliderProps) {
-  const [imageIndex, setImageIndex] = useState(0);
+  const [selectedImageIndex, setSelectedImageIndex] = useState(0);
+  const imageIndex = getValidRecipeImageIndex(selectedImageIndex, images.length);
   const heroImage = images[imageIndex];
   const hasMultipleImages = images.length > 1;
 
   const showPreviousImage = () => {
-    setImageIndex((current) => (current === 0 ? images.length - 1 : current - 1));
+    setSelectedImageIndex(imageIndex === 0 ? images.length - 1 : imageIndex - 1);
   };
 
   const showNextImage = () => {
-    setImageIndex((current) => (current === images.length - 1 ? 0 : current + 1));
+    setSelectedImageIndex(imageIndex === images.length - 1 ? 0 : imageIndex + 1);
   };
 
   return (

--- a/src/pages/recipes/RecipesPage.tsx
+++ b/src/pages/recipes/RecipesPage.tsx
@@ -7,6 +7,7 @@ import { Card } from '@/components/card/Card';
 import { FloatingButton } from '@/components/floating-button/FloatingButton';
 import { TextInput } from '@/components/text-input/TextInput';
 import { filterAndRankBySearch, type RankedSearchFields } from '@/lib/search/filterAndRankBySearch';
+import { takeGraphemes } from '@/lib/text/takeGraphemes';
 import type { RecipeLibraryItem } from './recipes.api';
 import css from './RecipesPage.module.css';
 
@@ -85,7 +86,7 @@ export function RecipesPage({ recipes }: RecipesPageProps) {
                 </div>
 
                 {recipe.description ? (
-                  <p className={css.description}>{recipe.description.slice(0, 280)}</p>
+                  <p className={css.description}>{takeGraphemes(recipe.description, 280)}</p>
                 ) : null}
 
                 <div className={css.recipeFooter}>

--- a/src/pages/recipes/recipeImageIndex.test.ts
+++ b/src/pages/recipes/recipeImageIndex.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { getValidRecipeImageIndex } from './recipeImageIndex';
+
+describe('getValidRecipeImageIndex', () => {
+  it.each([
+    [0, 1, 0],
+    [1, 2, 1],
+    [1, 1, 0],
+    [3, 0, 0],
+    [-1, 2, 0],
+    [0.5, 2, 0],
+  ])('clamps index %s for %s images to %s', (index, imageCount, expected) => {
+    expect(getValidRecipeImageIndex(index, imageCount)).toBe(expected);
+  });
+});

--- a/src/pages/recipes/recipeImageIndex.ts
+++ b/src/pages/recipes/recipeImageIndex.ts
@@ -1,0 +1,3 @@
+export function getValidRecipeImageIndex(index: number, imageCount: number) {
+  return Number.isInteger(index) && index >= 0 && index < imageCount ? index : 0;
+}

--- a/src/pages/recipes/recipeLibraryOrder.test.ts
+++ b/src/pages/recipes/recipeLibraryOrder.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { compareRecipeLibraryOrder } from './recipeLibraryOrder';
+
+describe('compareRecipeLibraryOrder', () => {
+  it('sorts newest updates first with a deterministic descending ID tie-breaker', () => {
+    const recipes = [
+      { id: 'a', updatedAt: '2026-01-02T00:00:00.000Z' },
+      { id: 'c', updatedAt: '2026-01-01T00:00:00.000Z' },
+      { id: 'b', updatedAt: '2026-01-02T00:00:00.000Z' },
+    ];
+
+    expect(recipes.toSorted(compareRecipeLibraryOrder).map((recipe) => recipe.id)).toEqual([
+      'b',
+      'a',
+      'c',
+    ]);
+    expect(recipes.map((recipe) => recipe.id)).toEqual(['a', 'c', 'b']);
+  });
+});

--- a/src/pages/recipes/recipeLibraryOrder.ts
+++ b/src/pages/recipes/recipeLibraryOrder.ts
@@ -1,0 +1,8 @@
+type OrderedRecipe = {
+  id: string;
+  updatedAt: string;
+};
+
+export function compareRecipeLibraryOrder(left: OrderedRecipe, right: OrderedRecipe) {
+  return right.updatedAt.localeCompare(left.updatedAt) || right.id.localeCompare(left.id);
+}

--- a/src/pages/recipes/recipeUploadInput.test.ts
+++ b/src/pages/recipes/recipeUploadInput.test.ts
@@ -1,0 +1,162 @@
+import { type } from 'arktype';
+import { describe, expect, it } from 'vitest';
+import {
+  exceedsRecipeUploadRequestLimit,
+  parseRecipeUploadForm,
+  RECIPE_UPLOAD_MAX_PHOTO_BYTES,
+  RECIPE_UPLOAD_MAX_PHOTO_COUNT,
+  RECIPE_UPLOAD_MAX_REQUEST_BYTES,
+} from './recipeUploadInput';
+
+function createValidFormData() {
+  const formData = new FormData();
+  formData.set('carbs', '20');
+  formData.set('description', 'A useful description');
+  formData.set('fats', '10');
+  formData.set('ingredients', 'first\nsecond');
+  formData.set('kcal', '100');
+  formData.set('name', 'Recipe');
+  formData.set('portions', '1');
+  formData.set('protein', '30');
+  formData.set('rating', '5');
+  formData.set('tags', 'quick, dinner');
+  return formData;
+}
+
+function expectValid(formData: FormData, files: File[] = []) {
+  const result = parseRecipeUploadForm(formData, files);
+  if (result instanceof type.errors) {
+    throw new Error(result.summary);
+  }
+  expect(result).not.toBeInstanceOf(type.errors);
+  return result;
+}
+
+describe('parseRecipeUploadForm', () => {
+  it('trims scalar values, splits collections, and maps blank optional numbers to null', () => {
+    const formData = createValidFormData();
+    formData.set('name', '  Recipe  ');
+    formData.set('kcal', '  ');
+    formData.set('ingredients', ' first \n\n second ');
+    formData.set('tags', ' quick, , dinner ');
+
+    expect(expectValid(formData)).toMatchObject({
+      ingredients: ['first', 'second'],
+      kcal: null,
+      name: 'Recipe',
+      tags: ['quick', 'dinner'],
+    });
+  });
+
+  it.each(['kcal', 'protein', 'carbs', 'fats'])(
+    'rejects database-incompatible %s values',
+    (field) => {
+      for (const value of ['-1', '1.5', '2147483648', '1e309', 'NaN', 'Infinity']) {
+        const formData = createValidFormData();
+        formData.set(field, value);
+        expect(parseRecipeUploadForm(formData, [])).toBeInstanceOf(type.errors);
+      }
+    },
+  );
+
+  it('accepts exact nutrient and portions boundaries', () => {
+    const formData = createValidFormData();
+    formData.set('kcal', '0');
+    formData.set('protein', '2147483647');
+    formData.set('portions', '2147483647');
+
+    expect(expectValid(formData)).toMatchObject({
+      kcal: 0,
+      portions: 2_147_483_647,
+      protein: 2_147_483_647,
+    });
+  });
+
+  it.each([
+    ['portions', '0'],
+    ['portions', '1.5'],
+    ['portions', '2147483648'],
+    ['rating', '0'],
+    ['rating', '1.5'],
+    ['rating', '6'],
+  ])('rejects invalid %s value %s', (field, value) => {
+    const formData = createValidFormData();
+    formData.set(field, value);
+    expect(parseRecipeUploadForm(formData, [])).toBeInstanceOf(type.errors);
+  });
+
+  it('enforces text, collection, photo count, and photo size boundaries', () => {
+    const exactBoundaryForm = createValidFormData();
+    exactBoundaryForm.set('name', 'n'.repeat(160));
+    exactBoundaryForm.set('description', 'd'.repeat(16_000));
+    exactBoundaryForm.set(
+      'ingredients',
+      Array.from({ length: 100 }, () => 'i'.repeat(500)).join('\n'),
+    );
+    exactBoundaryForm.set('tags', Array.from({ length: 30 }, () => 't'.repeat(80)).join(','));
+    const boundaryFiles = Array.from(
+      { length: RECIPE_UPLOAD_MAX_PHOTO_COUNT },
+      (_, index) =>
+        new File(
+          [index === 0 ? new Uint8Array(RECIPE_UPLOAD_MAX_PHOTO_BYTES) : 'x'],
+          `${index}.png`,
+          {
+            type: 'image/png',
+          },
+        ),
+    );
+
+    expectValid(exactBoundaryForm, boundaryFiles);
+
+    const cases: Array<(formData: FormData) => File[]> = [
+      (formData) => {
+        formData.set('name', 'n'.repeat(161));
+        return [];
+      },
+      (formData) => {
+        formData.set('description', 'd'.repeat(16_001));
+        return [];
+      },
+      (formData) => {
+        formData.set('ingredients', Array.from({ length: 101 }, () => 'i').join('\n'));
+        return [];
+      },
+      (formData) => {
+        formData.set('tags', Array.from({ length: 31 }, () => 't').join(','));
+        return [];
+      },
+      () =>
+        Array.from(
+          { length: RECIPE_UPLOAD_MAX_PHOTO_COUNT + 1 },
+          (_, index) => new File(['x'], `${index}.png`, { type: 'image/png' }),
+        ),
+      () => [
+        new File([new Uint8Array(RECIPE_UPLOAD_MAX_PHOTO_BYTES + 1)], 'large.png', {
+          type: 'image/png',
+        }),
+      ],
+    ];
+
+    for (const arrange of cases) {
+      const formData = createValidFormData();
+      expect(parseRecipeUploadForm(formData, arrange(formData))).toBeInstanceOf(type.errors);
+    }
+  });
+
+  it('rejects malformed multipart scalar types', () => {
+    const formData = createValidFormData();
+    formData.set('name', new File(['name'], 'name.txt', { type: 'text/plain' }));
+    expect(parseRecipeUploadForm(formData, [])).toBeInstanceOf(type.errors);
+  });
+});
+
+describe('exceedsRecipeUploadRequestLimit', () => {
+  it('rejects only known lengths above the request boundary', () => {
+    expect(exceedsRecipeUploadRequestLimit(String(RECIPE_UPLOAD_MAX_REQUEST_BYTES))).toBe(false);
+    expect(exceedsRecipeUploadRequestLimit(String(RECIPE_UPLOAD_MAX_REQUEST_BYTES + 1))).toBe(true);
+    expect(exceedsRecipeUploadRequestLimit('9'.repeat(400))).toBe(true);
+    expect(exceedsRecipeUploadRequestLimit(null)).toBe(false);
+    expect(exceedsRecipeUploadRequestLimit('chunked')).toBe(false);
+    expect(exceedsRecipeUploadRequestLimit('-1')).toBe(false);
+  });
+});

--- a/src/pages/recipes/recipeUploadInput.ts
+++ b/src/pages/recipes/recipeUploadInput.ts
@@ -1,0 +1,93 @@
+import { ArkErrors, type } from 'arktype';
+
+export const RECIPE_UPLOAD_MAX_PHOTO_COUNT = 8;
+export const RECIPE_UPLOAD_MAX_PHOTO_BYTES = 10 * 1024 * 1024;
+export const RECIPE_UPLOAD_MAX_REQUEST_BYTES = 82 * 1024 * 1024;
+
+const POSTGRES_INTEGER_MAX = 2_147_483_647;
+const optionalNutrientFormValueType = type('string.trim').pipe((value): number | null | ArkErrors =>
+  value === ''
+    ? null
+    : type(`string.numeric.parse |> 0 <= number.integer <= ${POSTGRES_INTEGER_MAX}`)(value),
+);
+const optionalRatingFormValueType = type('string.trim').pipe((value): number | null | ArkErrors =>
+  value === '' ? null : type('string.numeric.parse |> 1 <= number.integer <= 5')(value),
+);
+const portionsFormValueType = type('string.trim').pipe((value): number | ArkErrors =>
+  type(`string.numeric.parse |> 1 <= number.integer <= ${POSTGRES_INTEGER_MAX}`)(value),
+);
+const recipeUploadFormType = type({
+  carbs: optionalNutrientFormValueType,
+  description: 'string.trim |> string <= 16000',
+  fats: optionalNutrientFormValueType,
+  ingredients: 'string <= 64000',
+  kcal: optionalNutrientFormValueType,
+  name: 'string.trim |> 1 <= string <= 160',
+  portions: portionsFormValueType,
+  protein: optionalNutrientFormValueType,
+  rating: optionalRatingFormValueType,
+  tags: 'string <= 4000',
+});
+const recipePhotosType = type(`File[] <= ${RECIPE_UPLOAD_MAX_PHOTO_COUNT}`).narrow(
+  (files, context) =>
+    files.every((file) => file.size <= RECIPE_UPLOAD_MAX_PHOTO_BYTES) ||
+    context.mustBe(`files no larger than ${RECIPE_UPLOAD_MAX_PHOTO_BYTES} bytes`),
+);
+const recipeUploadInputType = type({
+  carbs: 'number | null',
+  description: 'string <= 16000',
+  fats: 'number | null',
+  ingredients: '(string <= 500)[] <= 100',
+  kcal: 'number | null',
+  name: '1 <= string <= 160',
+  photos: recipePhotosType,
+  portions: `1 <= number.integer <= ${POSTGRES_INTEGER_MAX}`,
+  protein: 'number | null',
+  rating: 'number | null',
+  tags: '(string <= 80)[] <= 30',
+});
+
+/** Parses multipart scalar values into the bounded shape accepted by recipe persistence. */
+export function parseRecipeUploadForm(formData: FormData, files: File[]) {
+  const ingredientsValue = formData.get('ingredients');
+  const tagsValue = formData.get('tags');
+  const formValidation = recipeUploadFormType({
+    carbs: formData.get('carbs'),
+    description: formData.get('description'),
+    fats: formData.get('fats'),
+    ingredients: typeof ingredientsValue === 'string' ? ingredientsValue : '',
+    kcal: formData.get('kcal'),
+    name: formData.get('name'),
+    portions: formData.get('portions'),
+    protein: formData.get('protein'),
+    rating: formData.get('rating'),
+    tags: typeof tagsValue === 'string' ? tagsValue : '',
+  });
+
+  if (formValidation instanceof type.errors) {
+    return formValidation;
+  }
+
+  return recipeUploadInputType({
+    ...formValidation,
+    ingredients: splitAndTrim(formValidation.ingredients, '\n'),
+    photos: files,
+    tags: splitAndTrim(formValidation.tags, ','),
+  });
+}
+
+export function exceedsRecipeUploadRequestLimit(contentLength: string | null) {
+  if (contentLength === null || !/^\d+$/.test(contentLength)) {
+    return false;
+  }
+
+  const parsedLength = Number(contentLength);
+  return !Number.isSafeInteger(parsedLength) || parsedLength > RECIPE_UPLOAD_MAX_REQUEST_BYTES;
+}
+
+function splitAndTrim(value: string, separator: string) {
+  return value
+    .split(separator)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}

--- a/src/pages/recipes/recipes.api.ts
+++ b/src/pages/recipes/recipes.api.ts
@@ -8,6 +8,7 @@ import { getSessionUserId, requireSession } from '@/lib/auth/getSession';
 import { ClientSafeError } from '@/lib/errors/ClientSafeError';
 import { logMiddleware } from '@/lib/middleware/logMiddleware';
 import { storagePathToUrl } from '@/lib/storage/config';
+import { compareRecipeLibraryOrder } from './recipeLibraryOrder';
 
 type RecipeSelect = typeof recipes.$inferSelect;
 
@@ -65,7 +66,7 @@ export const getRecipeLibrary = createServerFn({ method: 'GET' })
           updatedAt: recipe.updatedAt.toISOString(),
         }),
       )
-      .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+      .sort(compareRecipeLibraryOrder);
   });
 
 const recipeByIdInputType = type({ id: 'string.uuid' });

--- a/src/routes/api/recipes/upload.ts
+++ b/src/routes/api/recipes/upload.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { ArkErrors, type } from 'arktype';
+import { type } from 'arktype';
 import sharp from 'sharp';
 import { createFileRoute } from '@tanstack/react-router';
 import { db } from '@/db';
@@ -7,37 +7,14 @@ import { recipeImages, recipes, uploadObjects } from '@/db/schema';
 import { auth } from '@/lib/auth/auth';
 import { log } from '@/lib/logger';
 import { logMiddleware } from '@/lib/middleware/logMiddleware';
+import {
+  exceedsRecipeUploadRequestLimit,
+  parseRecipeUploadForm,
+  RECIPE_UPLOAD_MAX_PHOTO_BYTES,
+  RECIPE_UPLOAD_MAX_PHOTO_COUNT,
+} from '@/pages/recipes/recipeUploadInput';
 import { getStorageConfig } from '@/lib/storage/config';
 import { deleteFileByKey, uploadFileByKey } from '@/lib/storage/r2';
-
-export const RECIPE_UPLOAD_MAX_PHOTO_COUNT = 8;
-export const RECIPE_UPLOAD_MAX_PHOTO_BYTES = 10 * 1024 * 1024;
-
-const optionalNumericFormValueType = type('string.trim').pipe((value): number | null | ArkErrors =>
-  value === '' ? null : type('string.numeric.parse')(value),
-);
-
-const optionalRatingFormValueType = type('string.trim').pipe((value): number | null | ArkErrors =>
-  value === '' ? null : type('string.numeric.parse |> 1 <= number <= 5')(value),
-);
-
-const portionsFormValueType = type('string.trim').pipe((value): number | ArkErrors =>
-  type('string.numeric.parse |> number.integer >= 1')(value),
-);
-
-const uploadRecipeInputType = type({
-  carbs: optionalNumericFormValueType,
-  description: 'string.trim',
-  fats: optionalNumericFormValueType,
-  ingredients: 'string[]',
-  kcal: optionalNumericFormValueType,
-  name: 'string.trim |> string >= 1',
-  photos: 'File[]',
-  portions: portionsFormValueType,
-  protein: optionalNumericFormValueType,
-  rating: optionalRatingFormValueType,
-  tags: 'string[]',
-});
 
 export const Route = createFileRoute('/api/recipes/upload')({
   server: {
@@ -53,6 +30,10 @@ export const Route = createFileRoute('/api/recipes/upload')({
             return Response.json({ error: 'Unauthorized' }, { status: 401 });
           }
 
+          if (exceedsRecipeUploadRequestLimit(request.headers.get('content-length'))) {
+            return Response.json({ error: 'Upload request too large' }, { status: 413 });
+          }
+
           const formData = await request.formData();
           const files = formData
             .getAll('photos')
@@ -66,7 +47,7 @@ export const Route = createFileRoute('/api/recipes/upload')({
             return Response.json({ error: `File too large` }, { status: 400 });
           }
 
-          const validation = validateRecipeForm(formData, files);
+          const validation = parseRecipeUploadForm(formData, files);
 
           if (validation instanceof type.errors) {
             return Response.json(
@@ -163,37 +144,6 @@ export const Route = createFileRoute('/api/recipes/upload')({
     },
   },
 });
-
-function validateRecipeForm(formData: FormData, files: File[]) {
-  const ingredientsValue = formData.get('ingredients');
-  const tagsValue = formData.get('tags');
-
-  return uploadRecipeInputType({
-    carbs: formData.get('carbs'),
-    description: formData.get('description'),
-    fats: formData.get('fats'),
-    ingredients:
-      typeof ingredientsValue === 'string'
-        ? ingredientsValue
-            .split('\n')
-            .map((item) => item.trim())
-            .filter(Boolean)
-        : [],
-    kcal: formData.get('kcal'),
-    name: formData.get('name'),
-    photos: files,
-    portions: formData.get('portions'),
-    protein: formData.get('protein'),
-    rating: formData.get('rating'),
-    tags:
-      typeof tagsValue === 'string'
-        ? tagsValue
-            .split(',')
-            .map((item) => item.trim())
-            .filter(Boolean)
-        : [],
-  });
-}
 
 async function optimizeImage(file: File) {
   if (!file.type.startsWith('image/')) {

--- a/src/styles/theme.test.ts
+++ b/src/styles/theme.test.ts
@@ -3,37 +3,70 @@ import { resolve } from 'node:path';
 import process from 'node:process';
 import { describe, expect, it } from 'vitest';
 
+function withoutComments(source: string) {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+function getDeclaredTokens(source: string) {
+  return new Set(
+    Array.from(withoutComments(source).matchAll(/(--[A-Za-z0-9_-]+)\s*:/g), (match) => match[1]!),
+  );
+}
+
+function getTokenReferences(source: string) {
+  return Array.from(withoutComments(source).matchAll(/var\(\s*(--[A-Za-z0-9_-]+)/g));
+}
+
 describe('theme tokens', () => {
+  it('distinguishes declarations from references and comments', () => {
+    const source = `
+      /* --comment-only: red; var(--ignored-reference); */
+      :root {
+        --known: var(--missing);
+      }
+    `;
+
+    expect(getDeclaredTokens(source)).toEqual(new Set(['--known']));
+    expect(getTokenReferences(source).map((match) => match[1])).toEqual(['--missing']);
+  });
+
   it('only uses defined CSS variables', async () => {
     const root = process.cwd();
     const themePath = resolve(root, 'src/styles/theme.css');
     const themeSource = await readFile(themePath, 'utf8');
-    const declaredTokens = new Set(themeSource.match(/--[a-z0-9-]+/g) ?? []);
-    const allowedLocalPrefixes = [
-      '--btn-',
-      '--duration',
-      '--easing',
-      '--positioner-',
-      '--available-',
-      '--popup-',
-      '--transform-origin',
+    const themeTokens = getDeclaredTokens(themeSource);
+    const externallyProvidedTokens = new Set([
       '--anchor-width',
-      '--card-padding',
-      '--toast-',
-    ];
+      '--available-height',
+      '--available-width',
+      '--btn-bg-position-hover',
+      '--btn-border-width',
+      '--popup-height',
+      '--popup-width',
+      '--positioner-height',
+      '--positioner-width',
+      '--toast-frontmost-height',
+      '--toast-height',
+      '--toast-index',
+      '--toast-offset-y',
+      '--toast-swipe-movement-x',
+      '--toast-swipe-movement-y',
+      '--transform-origin',
+    ]);
     const errors: string[] = [];
 
     for await (const relativePath of glob('src/**/*.css', { cwd: root })) {
       const filePath = resolve(root, relativePath);
       const source = await readFile(filePath, 'utf8');
-      const matches = source.matchAll(/var\((--[a-z0-9-]+)/g);
+      const localTokens = getDeclaredTokens(source);
 
-      for (const match of matches) {
+      for (const match of getTokenReferences(source)) {
         const token = match[1]!;
 
         if (
-          declaredTokens.has(token) ||
-          allowedLocalPrefixes.some((prefix) => token.startsWith(prefix))
+          themeTokens.has(token) ||
+          localTokens.has(token) ||
+          externallyProvidedTokens.has(token)
         ) {
           continue;
         }


### PR DESCRIPTION
## Purpose

The repository started with 5 tests across 3 files, leaving important persistence, upload, asynchronous-state, Unicode, and configuration boundaries unprotected. This PR performs an adversarial unit-test sweep against malformed values, exact boundaries, race ordering, identity collisions, resource limits, invalid state, environment leakage, and false-positive test oracles.

The resulting suite contains 80 passing tests across 12 files. The implementation changes are deliberately tied to concrete defects discovered by that sweep rather than speculative architecture changes.

## Recipe Upload Validation

Recipe multipart parsing now lives in the pure, directly testable `recipeUploadInput.ts` boundary instead of being embedded in the API route.

- Nutrient values must be non-negative PostgreSQL-compatible integers or blank/null.
- Portions must be an integer from 1 through PostgreSQL's signed 32-bit maximum.
- Ratings must be integer values from 1 through 5 or blank/null.
- Negative values, decimals, overflow values, `NaN`, `Infinity`, and overflowing exponent notation are rejected before storage or database work.
- Exact accepted boundaries such as nutrient `0`, portions `1`, and `2147483647` are permanently covered.
- Recipe names are trimmed and bounded to 160 characters.
- Descriptions are trimmed and bounded to 16,000 characters.
- Ingredient input is bounded to 64,000 characters, 100 parsed items, and 500 characters per item.
- Tag input is bounded to 4,000 characters, 30 parsed items, and 80 characters per item.
- Empty collection entries are removed after trimming.
- Multipart scalar fields containing `File` values instead of strings are rejected.
- Photo count remains capped at 8 and each photo remains capped at 10 MiB, with exact-limit and limit-plus-one tests.
- Requests with a known `Content-Length` above 82 MiB now return `413` before multipart materialization.
- Shared upload constants moved out of the server route so the client no longer imports route implementation code.

## Diary Correctness And Concurrency

Diary dates now use strict Gregorian calendar validation rather than ArkType's permissive JavaScript-date coercion.

- Only canonical `YYYY-MM-DD` values are accepted.
- Real leap days are accepted.
- Invalid leap days, impossible month lengths, month/day zero, out-of-range months and days, missing zero padding, timestamps, whitespace, year zero, and miscellaneous JavaScript-parseable values are rejected.
- The supported calendar range is explicitly exercised from `0001-01-01` through `9999-12-31`.

Diary autosaves are now serialized through `createSequentialTaskQueue`.

- A newer save cannot start while an older save is still in flight.
- An older request can therefore no longer finish after and overwrite a newer draft.
- `DiaryEntryPage` uses `mutateAsync`, ensuring the queue tracks the actual network mutation rather than the synchronous enqueue call.
- A failed save does not permanently block later queued saves.
- Regression tests use deferred promises to prove start and settlement ordering, including failure recovery.

Diary list ordering also gains a descending ID tie-breaker after date and creation timestamp, eliminating unstable ordering when timestamps collide.

## Upload Selection And File Identity

Upload selection logic moved into a small pure helper with focused boundary tests.

- Files are identified by object identity rather than `name-size-lastModified` metadata.
- Two genuinely different files with identical browser metadata are retained instead of being silently deduplicated.
- Removing one colliding file no longer removes every file sharing that metadata.
- Re-adding the exact same `File` object is still deduplicated.
- Stable per-object render keys prevent React key collisions.
- Exact file-size and item-count limits are tested.
- Browser acceptance now follows the server's MIME-based image policy, preventing extension-only files from being accepted in the UI and deterministically rejected by the server.
- Extensionless, hidden, and trailing-dot filenames derive useful metadata from MIME type rather than displaying the entire filename as an extension.

## Unicode And Text Handling

Text behavior now handles canonically equivalent and multi-code-unit characters safely.

- Search normalizes query and candidate text to NFC before case folding.
- Composed and decomposed forms such as `Café` and `Cafe\u0301` now match in either direction.
- Search tests continue to protect rank priority, source ordering, highest-rank deduplication, input immutability, blank searches, and no-match behavior.
- `takeGraphemes` uses `Intl.Segmenter` so truncation cannot split surrogate pairs, combining sequences, emoji, or joined emoji families.
- Navigation initials and recipe description previews use grapheme-safe truncation.
- Zero, negative, `NaN`, and infinite truncation limits are handled without returning accidental unbounded text.

## Deterministic UI State And Ordering

- Recipe library ordering remains newest-first and now uses descending recipe ID as a deterministic tie-breaker for equal timestamps.
- The comparator is tested without mutating its input collection.
- Recipe carousel indexes are clamped when the image collection shrinks or becomes empty.
- A stale selected index no longer displays the empty fallback while a valid image exists.
- Negative, fractional, empty-collection, and out-of-range carousel indexes are covered.

## Environment And Storage Boundaries

- Required server environment variables now reject whitespace-only values.
- `BETTER_AUTH_SECRET` now enforces Better Auth's 32-character minimum.
- Error messages identify the invalid variable without exposing the submitted secret value.
- Environment tests explicitly isolate and restore process variables to prevent local shell configuration from affecting results.
- Optional app/CDN fallback behavior and explicit override behavior are covered.
- Storage public URL selection still prefers `R2_PUBLIC_URL` over the CDN fallback.
- Storage URL joining now removes repeated boundary slashes and always produces exactly one separator.
- Null, undefined, empty path, missing public URL, explicit R2 URL, and CDN fallback cases are covered.

## Test Oracle Hardening

The previous CSS-token test treated every custom-property occurrence as a declaration. A missing token referenced inside `theme.css` could therefore declare itself and escape detection.

- Declaration parsing now requires a custom-property declaration followed by `:`.
- `var(...)` references are collected independently.
- CSS comments are excluded from both sets.
- Theme declarations, file-local declarations, and an exact allowlist of framework-provided runtime variables are handled separately.
- Broad prefix allowlists were removed, preventing misspellings such as an unknown `--btn-*` or `--toast-*` token from passing automatically.
- A fixture regression proves that comment-only tokens are ignored and a referenced-but-undeclared token is detected.

The invariant helper also now has direct coverage proving that only `null` and `undefined` violate the invariant, while valid falsy values remain accepted and callback-thrown errors preserve their identity.

## Test Suite Result

- Before: 5 tests across 3 files.
- After: 80 tests across 12 files.
- Added coverage targets malformed multipart values, numeric overflow, exact integer limits, collection exhaustion, image count/size limits, calendar correctness, asynchronous race ordering, failure recovery, object-identity collisions, Unicode normalization, grapheme boundaries, deterministic ordering, stale carousel indexes, environment isolation, URL joining, invariant semantics, and the CSS test oracle itself.
- Existing meaningful search behavior was retained and expanded rather than replaced with duplicated assertions.
- Upload implementation details were consolidated into pure helpers so tests exercise meaningful behavior without brittle framework or database mocks.

## Verification

- `pnpm check:fix`
- `pnpm build`
- 12 test files passed.
- 80 tests passed.
- TypeScript passed with no emitted output.
- CSS linting and formatting passed.
- Client, SSR, and Nitro production builds completed successfully.

## Operational Notes

- No Drizzle schema or migration changes are included.
- The request-size guard can reject oversized requests when `Content-Length` is available; deployment-level body limits are still required for chunked or headerless multipart requests before `request.formData()` buffers them.
- Database, R2, and browser integration tests remain outside this unit-focused change; persistence constraints are represented at the pure parsing boundary.
- The build retains the repository's existing large client chunk warning.
- Local verification used Node 24.15.0 while `package.json` declares Node 26.2.0 or newer; all checks and builds completed successfully despite that local engine warning.