### PR TITLE
feat: add todos mock route

### DIFF
--- a/src/components/nav-menu/MobileNavMenu.module.css
+++ b/src/components/nav-menu/MobileNavMenu.module.css
@@ -9,7 +9,7 @@
 
 .group {
   display: grid;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(6, minmax(0, 1fr));
   gap: 0.25rem;
   padding: 0.3rem;
   border: 1px solid rgba(148, 163, 184, 0.26);

--- a/src/components/nav-menu/MobileNavMenu.tsx
+++ b/src/components/nav-menu/MobileNavMenu.tsx
@@ -7,6 +7,7 @@ import {
   FlameIcon,
   LogInIcon,
   NotebookPenIcon,
+  ListTodoIcon,
   ScaleIcon,
   UserIcon,
 } from 'lucide-react';
@@ -19,6 +20,7 @@ const itemIcons = {
   diary: NotebookPenIcon,
   login: LogInIcon,
   recipes: BookOpenIcon,
+  todos: ListTodoIcon,
   weight: ScaleIcon,
 } as const;
 

--- a/src/components/nav-menu/useNavMenuGroups.tsx
+++ b/src/components/nav-menu/useNavMenuGroups.tsx
@@ -80,7 +80,7 @@ export function useDesktopNavMenu() {
     {
       key: 'trackers',
       label: 'Trackers',
-      matchPrefixes: ['/weight', '/recipes', '/diary'],
+      matchPrefixes: ['/weight', '/recipes', '/diary', '/todos'],
       shouldRender: Boolean(user),
       items: [
         {
@@ -100,6 +100,12 @@ export function useDesktopNavMenu() {
           link: '/diary',
           label: 'Diary',
           description: 'Private personal entries and imported journals.',
+        },
+        {
+          key: 'todos',
+          link: '/todos',
+          label: 'Todos',
+          description: 'Shared checklists for shopping and life goals.',
         },
       ],
     },
@@ -136,6 +142,12 @@ export const MOBILE_NAV_ITEMS = [
     label: 'Diary',
     link: '/diary',
     matchPrefixes: ['/diary'],
+  },
+  {
+    key: 'todos',
+    label: 'Todos',
+    link: '/todos',
+    matchPrefixes: ['/todos'],
   },
   {
     key: 'recipes',

--- a/src/pages/todos/TodosPage.module.css
+++ b/src/pages/todos/TodosPage.module.css
@@ -1,0 +1,86 @@
+.page {
+  display: grid;
+  gap: var(--space-lg);
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-lg);
+}
+
+.header h1,
+.listCard h2 {
+  margin: 0;
+  text-wrap: balance;
+}
+
+.header p {
+  margin: var(--space-xs) 0 0;
+  color: var(--c-muted);
+  text-wrap: pretty;
+}
+
+.mockNote {
+  width: fit-content;
+  margin: 0;
+  padding: 0.35rem 0.65rem;
+  border: var(--border-width) solid var(--c-primary-border-soft);
+  border-radius: var(--radius-pill);
+  background: var(--c-primary-surface);
+  color: var(--c-accent-soft);
+  font-size: var(--text-xs);
+}
+
+.listGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-lg);
+}
+
+.listCard {
+  display: grid;
+  align-content: start;
+  gap: var(--space-md);
+}
+
+.items {
+  display: grid;
+  gap: var(--space-sm);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  min-height: var(--button-min-height);
+  padding: 0 var(--space-xs);
+  border-radius: var(--radius-xs);
+}
+
+.item input {
+  width: 1.15rem;
+  height: 1.15rem;
+  margin: 0;
+  accent-color: var(--c-primary);
+}
+
+.done {
+  color: var(--c-muted-strong);
+  text-decoration: line-through;
+}
+
+@media (--phone) {
+  .header,
+  .listGrid {
+    display: grid;
+  }
+
+  .listGrid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/pages/todos/TodosPage.tsx
+++ b/src/pages/todos/TodosPage.tsx
@@ -1,0 +1,64 @@
+import { Share2Icon } from 'lucide-react';
+import { Btn } from '@/components/btn/Btn';
+import { Card } from '@/components/card/Card';
+import css from './TodosPage.module.css';
+
+const todoLists = [
+  {
+    title: 'Shopping cart',
+    items: [
+      { done: false, text: 'Oats and Greek yogurt' },
+      { done: true, text: 'Coffee beans' },
+      { done: false, text: 'Vegetables for stir-fry' },
+      { done: false, text: 'Cat food' },
+    ],
+  },
+  {
+    title: 'Life goals',
+    items: [
+      { done: true, text: 'Renew passport' },
+      { done: false, text: 'Plan the balcony garden' },
+      { done: false, text: 'Book a Polish conversation class' },
+    ],
+  },
+] as const;
+
+export function TodosPage() {
+  return (
+    <main className={css.page}>
+      <header className={css.header}>
+        <div>
+          <h1>Todos</h1>
+          <p>Simple checklists for your shopping cart and life goals.</p>
+        </div>
+        <Btn
+          disabled
+          icon={<Share2Icon aria-hidden='true' />}
+          radius='pill'
+          type='button'
+          variant='outlineMain'
+        >
+          Share soon
+        </Btn>
+      </header>
+
+      <p className={css.mockNote}>Mock only — editing and sharing are coming next.</p>
+
+      <section aria-label='Example todo lists' className={css.listGrid}>
+        {todoLists.map((list) => (
+          <Card as='article' className={css.listCard} key={list.title}>
+            <h2>{list.title}</h2>
+            <ul className={css.items}>
+              {list.items.map((item) => (
+                <li className={css.item} key={item.text}>
+                  <input defaultChecked={item.done} disabled type='checkbox' />
+                  <span className={item.done ? css.done : undefined}>{item.text}</span>
+                </li>
+              ))}
+            </ul>
+          </Card>
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as DemoTanstackQueryRouteImport } from './routes/demo/tanstack-query'
 import { Route as DemoComponentsRouteImport } from './routes/demo/components'
 import { Route as AuthenticatedWeightRouteImport } from './routes/_authenticated/weight'
+import { Route as AuthenticatedTodosRouteImport } from './routes/_authenticated/todos'
 import { Route as AuthenticatedCaloriesRouteImport } from './routes/_authenticated/calories'
 import { Route as AuthenticatedAccountRouteImport } from './routes/_authenticated/account'
 import { Route as AuthenticatedRecipesIndexRouteImport } from './routes/_authenticated/recipes/index'
@@ -60,6 +61,11 @@ const DemoComponentsRoute = DemoComponentsRouteImport.update({
 const AuthenticatedWeightRoute = AuthenticatedWeightRouteImport.update({
   id: '/weight',
   path: '/weight',
+  getParentRoute: () => AuthenticatedRoute,
+} as any)
+const AuthenticatedTodosRoute = AuthenticatedTodosRouteImport.update({
+  id: '/todos',
+  path: '/todos',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
 const AuthenticatedCaloriesRoute = AuthenticatedCaloriesRouteImport.update({
@@ -156,6 +162,7 @@ export interface FileRoutesByFullPath {
   '/login': typeof LoginRoute
   '/account': typeof AuthenticatedAccountRoute
   '/calories': typeof AuthenticatedCaloriesRoute
+  '/todos': typeof AuthenticatedTodosRoute
   '/weight': typeof AuthenticatedWeightRoute
   '/demo/components': typeof DemoComponentsRoute
   '/demo/tanstack-query': typeof DemoTanstackQueryRoute
@@ -180,6 +187,7 @@ export interface FileRoutesByTo {
   '/login': typeof LoginRoute
   '/account': typeof AuthenticatedAccountRoute
   '/calories': typeof AuthenticatedCaloriesRoute
+  '/todos': typeof AuthenticatedTodosRoute
   '/weight': typeof AuthenticatedWeightRoute
   '/demo/components': typeof DemoComponentsRoute
   '/demo/tanstack-query': typeof DemoTanstackQueryRoute
@@ -206,6 +214,7 @@ export interface FileRoutesById {
   '/login': typeof LoginRoute
   '/_authenticated/account': typeof AuthenticatedAccountRoute
   '/_authenticated/calories': typeof AuthenticatedCaloriesRoute
+  '/_authenticated/todos': typeof AuthenticatedTodosRoute
   '/_authenticated/weight': typeof AuthenticatedWeightRoute
   '/demo/components': typeof DemoComponentsRoute
   '/demo/tanstack-query': typeof DemoTanstackQueryRoute
@@ -232,6 +241,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/account'
     | '/calories'
+    | '/todos'
     | '/weight'
     | '/demo/components'
     | '/demo/tanstack-query'
@@ -256,6 +266,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/account'
     | '/calories'
+    | '/todos'
     | '/weight'
     | '/demo/components'
     | '/demo/tanstack-query'
@@ -281,6 +292,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/_authenticated/account'
     | '/_authenticated/calories'
+    | '/_authenticated/todos'
     | '/_authenticated/weight'
     | '/demo/components'
     | '/demo/tanstack-query'
@@ -360,6 +372,13 @@ declare module '@tanstack/react-router' {
       path: '/weight'
       fullPath: '/weight'
       preLoaderRoute: typeof AuthenticatedWeightRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/_authenticated/todos': {
+      id: '/_authenticated/todos'
+      path: '/todos'
+      fullPath: '/todos'
+      preLoaderRoute: typeof AuthenticatedTodosRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
     '/_authenticated/calories': {
@@ -487,6 +506,7 @@ declare module '@tanstack/react-router' {
 interface AuthenticatedRouteChildren {
   AuthenticatedAccountRoute: typeof AuthenticatedAccountRoute
   AuthenticatedCaloriesRoute: typeof AuthenticatedCaloriesRoute
+  AuthenticatedTodosRoute: typeof AuthenticatedTodosRoute
   AuthenticatedWeightRoute: typeof AuthenticatedWeightRoute
   AuthenticatedDiaryIdRoute: typeof AuthenticatedDiaryIdRoute
   AuthenticatedRecipesAddRoute: typeof AuthenticatedRecipesAddRoute
@@ -499,6 +519,7 @@ interface AuthenticatedRouteChildren {
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedAccountRoute: AuthenticatedAccountRoute,
   AuthenticatedCaloriesRoute: AuthenticatedCaloriesRoute,
+  AuthenticatedTodosRoute: AuthenticatedTodosRoute,
   AuthenticatedWeightRoute: AuthenticatedWeightRoute,
   AuthenticatedDiaryIdRoute: AuthenticatedDiaryIdRoute,
   AuthenticatedRecipesAddRoute: AuthenticatedRecipesAddRoute,

--- a/src/routes/_authenticated/todos.tsx
+++ b/src/routes/_authenticated/todos.tsx
@@ -1,0 +1,8 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { TodosPage } from '@/pages/todos/TodosPage';
+
+export const Route = createFileRoute('/_authenticated/todos')({
+  component: TodosPage,
+  head: () => ({ meta: [{ title: 'Todos' }] }),
+  staticData: { navbar: { label: 'Todos', upTo: { to: '/' } } },
+});


### PR DESCRIPTION
## Summary
- add an authenticated `/todos` mock route with shopping-cart and life-goal checklist examples
- show Todos in both desktop and mobile navigation
- keep editing and sharing visibly marked as future work

## Test plan
- `pnpm check:fix`
- `CI=1 pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Todos page with two todo lists and completion checkboxes.
  * Added Todos to desktop and mobile navigation.
  * Added authenticated `/todos` routing and page metadata.
  * Added responsive layouts and completed-item styling.
  * Added a disabled “Share soon” button for future functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->