### PR TITLE
Add mobile browser theme color

### DIFF
--- a/apps/web/public/site-localhost.webmanifest
+++ b/apps/web/public/site-localhost.webmanifest
@@ -5,7 +5,7 @@
     { "src": "/android-chrome-192x192-localhost.png", "sizes": "192x192", "type": "image/png" },
     { "src": "/android-chrome-512x512-localhost.png", "sizes": "512x512", "type": "image/png" }
   ],
-  "theme_color": "#060816",
+  "theme_color": "#2563eb",
   "background_color": "#060816",
   "display": "standalone"
 }

--- a/apps/web/public/site.webmanifest
+++ b/apps/web/public/site.webmanifest
@@ -5,7 +5,7 @@
     { "src": "/android-chrome-192x192.png", "sizes": "192x192", "type": "image/png" },
     { "src": "/android-chrome-512x512.png", "sizes": "512x512", "type": "image/png" }
   ],
-  "theme_color": "#060816",
+  "theme_color": "#2563eb",
   "background_color": "#060816",
   "display": "standalone"
 }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -32,6 +32,7 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
     meta: [
       { charSet: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+      { name: 'theme-color', content: '#2563eb' },
       { title: clientEnv.appName },
       {
         name: 'description',


### PR DESCRIPTION
## Summary
- use the existing primary blue palette color for both web app manifests
- add matching theme-color metadata for mobile browser chrome
- retain the dark palette background for installed-app launch screens

## Verification
- pnpm check:fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the browser and installed app theme color to blue for a more consistent visual experience.
  * Applied the new theme color across supported environments, including local development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->