### PR TITLE
Match mobile chrome to dark app background

### DIFF
--- a/apps/web/public/site-localhost.webmanifest
+++ b/apps/web/public/site-localhost.webmanifest
@@ -5,7 +5,7 @@
     { "src": "/android-chrome-192x192-localhost.png", "sizes": "192x192", "type": "image/png" },
     { "src": "/android-chrome-512x512-localhost.png", "sizes": "512x512", "type": "image/png" }
   ],
-  "theme_color": "#2563eb",
+  "theme_color": "#060816",
   "background_color": "#060816",
   "display": "standalone"
 }

--- a/apps/web/public/site.webmanifest
+++ b/apps/web/public/site.webmanifest
@@ -5,7 +5,7 @@
     { "src": "/android-chrome-192x192.png", "sizes": "192x192", "type": "image/png" },
     { "src": "/android-chrome-512x512.png", "sizes": "512x512", "type": "image/png" }
   ],
-  "theme_color": "#2563eb",
+  "theme_color": "#060816",
   "background_color": "#060816",
   "display": "standalone"
 }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -32,7 +32,7 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
     meta: [
       { charSet: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-      { name: 'theme-color', content: '#2563eb' },
+      { name: 'theme-color', content: '#060816' },
       { title: clientEnv.appName },
       {
         name: 'description',


### PR DESCRIPTION
## Summary
- replace the saturated blue mobile chrome with the page gradient's dark `#060816` color
- keep browser metadata and both installed-app manifests consistent
- make Android status and navigation chrome blend into the app canvas

## Verification
- pnpm check:fix