### PR TITLE
Fix navbar session hydration

### DIFF
--- a/apps/web/src/components/app-frame/AppFrame.tsx
+++ b/apps/web/src/components/app-frame/AppFrame.tsx
@@ -5,10 +5,17 @@ import type { ReactNode } from 'react';
 import { Btn } from '@/components/btn/Btn';
 import { NavMenu } from '@/components/nav-menu/NavMenu';
 import { MobileNavMenu } from '@/components/nav-menu/MobileNavMenu';
+import type { SessionUser } from '@/lib/auth/session.api';
 import type { NavbarTarget } from '@/lib/routing/staticRouteData';
 import css from './AppFrame.module.css';
 
-export function AppFrame({ children }: { children?: ReactNode }) {
+export function AppFrame({
+  children,
+  user = null,
+}: {
+  children?: ReactNode;
+  user?: SessionUser | null;
+}) {
   const navbar = useRouterState({
     select: (state) => {
       const match = state.matches.at(-1);
@@ -33,10 +40,10 @@ export function AppFrame({ children }: { children?: ReactNode }) {
       <div className={css.shell}>
         <header className={clsx(css.header, !navbar && css.headerDefaultBrand)}>
           {navbar ? <RouteLabel label={navbar.label} upTo={navbar.upTo} /> : <div />}
-          <NavMenu />
+          <NavMenu user={user} />
         </header>
         {children === undefined ? <Outlet /> : children}
-        <MobileNavMenu />
+        <MobileNavMenu user={user} />
       </div>
     </div>
   );

--- a/apps/web/src/components/nav-menu/MobileNavMenu.tsx
+++ b/apps/web/src/components/nav-menu/MobileNavMenu.tsx
@@ -11,6 +11,7 @@ import {
   ScaleIcon,
   UserIcon,
 } from 'lucide-react';
+import type { SessionUser } from '@/lib/auth/session.api';
 import css from './MobileNavMenu.module.css';
 import { useMobileNavItems } from './useNavMenuGroups';
 
@@ -24,12 +25,12 @@ const itemIcons = {
   weight: ScaleIcon,
 } as const;
 
-export function MobileNavMenu() {
+export function MobileNavMenu({ user }: { user: SessionUser | null }) {
   const navigate = useNavigate();
   const pathname = useRouterState({
     select: (state) => state.location.pathname,
   });
-  const items = useMobileNavItems();
+  const items = useMobileNavItems(user);
   const activeValue = items.find((item) =>
     item.matchPrefixes.some((prefix) => pathname.startsWith(prefix)),
   )?.key;

--- a/apps/web/src/components/nav-menu/NavMenu.tsx
+++ b/apps/web/src/components/nav-menu/NavMenu.tsx
@@ -2,14 +2,15 @@ import { NavigationMenu } from '@base-ui/react/navigation-menu';
 import { Link, useRouterState } from '@tanstack/react-router';
 import { ChevronDownIcon } from 'lucide-react';
 import { useState } from 'react';
+import type { SessionUser } from '@/lib/auth/session.api';
 import css from './NavMenu.module.css';
 import { useDesktopNavMenu } from './useNavMenuGroups';
 
-export function NavMenu() {
+export function NavMenu({ user }: { user: SessionUser | null }) {
   const pathname = useRouterState({
     select: (state) => state.location.pathname,
   });
-  const groups = useDesktopNavMenu();
+  const groups = useDesktopNavMenu(user);
   const [value, setValue] = useState<string | null>(null);
 
   return (

--- a/apps/web/src/components/nav-menu/useNavMenuGroups.tsx
+++ b/apps/web/src/components/nav-menu/useNavMenuGroups.tsx
@@ -1,22 +1,18 @@
 import { Avatar } from '@base-ui/react/avatar';
 import { useNavigate } from '@tanstack/react-router';
 import { type ReactNode, useState } from 'react';
-import { signOut, useSession } from '@/lib/auth/client';
+import { signOut } from '@/lib/auth/client';
+import type { SessionUser } from '@/lib/auth/session.api';
 import css from './NavMenu.module.css';
 
 type MobileAccountLink = '/account' | '/login';
-type SessionUser = {
-  email?: string | null;
-  image?: string | null;
-  name?: string | null;
-};
 
 export type MobileAccountItem = {
   key: 'account';
   label: string;
   link: MobileAccountLink;
   matchPrefixes: string[];
-  user: SessionUser | null | undefined;
+  user: SessionUser | null;
 };
 
 export interface NavMenuGroup {
@@ -37,10 +33,8 @@ export interface NavMenuItem {
   disabled?: boolean;
 }
 
-export function useDesktopNavMenu() {
+export function useDesktopNavMenu(user: SessionUser | null) {
   const navigate = useNavigate();
-  const { data: session } = useSession();
-  const user = session?.user;
   const [logoutBusy, setLogoutBusy] = useState(false);
   const accountInitials = getInitials(user?.name ?? user?.email ?? 'Account');
 
@@ -171,10 +165,7 @@ export const MOBILE_NAV_ITEMS = [
 
 export type MobileNavItem = (typeof MOBILE_NAV_ITEMS)[number];
 
-export function useMobileNavItems() {
-  const { data: session } = useSession();
-  const user = session?.user;
-
+export function useMobileNavItems(user: SessionUser | null) {
   const mobileAccountItem: MobileAccountItem = {
     key: 'account',
     label: user ? 'Account' : 'Login',

--- a/apps/web/src/lib/auth/session.api.ts
+++ b/apps/web/src/lib/auth/session.api.ts
@@ -1,0 +1,27 @@
+import { createServerFn } from '@tanstack/react-start';
+import { logMiddleware } from '@/lib/middleware/logMiddleware';
+import { getSession } from './getSession';
+
+export interface SessionUser {
+  id: string;
+  email: string;
+  image: string | null;
+  name: string;
+}
+
+export const getSessionUser = createServerFn({ method: 'GET' })
+  .middleware([logMiddleware('getSessionUser')])
+  .handler(async (): Promise<SessionUser | null> => {
+    const session = await getSession();
+
+    if (!session) {
+      return null;
+    }
+
+    return {
+      id: session.user.id,
+      email: session.user.email,
+      image: session.user.image ?? null,
+      name: session.user.name,
+    };
+  });

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -3,6 +3,7 @@ import { AppFrame } from '@/components/app-frame/AppFrame';
 import { DefaultCatchBoundary } from '@/components/default-catch-boundary/DefaultCatchBoundary';
 import { NotFound } from '@/components/not-found/NotFound';
 import { ToastProvider } from '@/components/toast/ToastProvider';
+import { getSessionUser } from '@/lib/auth/session.api';
 import { clientEnv } from '@/lib/env/client';
 import resetCss from '@/styles/reset.css?url';
 import type { QueryClient } from '@tanstack/react-query';
@@ -28,6 +29,7 @@ const faviconLinks = isLocalhostApp
     ];
 
 export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()({
+  beforeLoad: async () => ({ user: await getSessionUser() }),
   head: () => ({
     meta: [
       { charSet: 'utf-8' },
@@ -54,10 +56,12 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
 });
 
 function RootComponent() {
+  const { user } = Route.useRouteContext();
+
   return (
     <RootDocument>
       <ToastProvider>
-        <AppFrame />
+        <AppFrame user={user} />
       </ToastProvider>
     </RootDocument>
   );

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -1,15 +1,9 @@
 import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
-import { createServerFn } from '@tanstack/react-start';
 import { getSafeRedirectPath } from '@/lib/auth/getSafeRedirectPath';
-import { getSessionUserId } from '@/lib/auth/getSession';
-
-const hasSession = createServerFn({ method: 'GET' }).handler(async () =>
-  Boolean(await getSessionUserId()),
-);
 
 export const Route = createFileRoute('/_authenticated')({
-  beforeLoad: async ({ location }) => {
-    if (!(await hasSession())) {
+  beforeLoad: ({ context, location }) => {
+    if (!context.user) {
       throw redirect({
         to: '/login',
         search: { redirect: getSafeRedirectPath(location.href) },


### PR DESCRIPTION
## Summary
- load a client-safe Better Auth user in the root route during SSR
- reuse the root auth context for protected-route redirects
- render desktop and mobile navigation from the hydrated user instead of a client-only session fetch

## Verification
- pnpm check:fix
- pnpm --filter @veles/web build