### PR TITLE
Restore components demo

### DIFF
--- a/apps/web/src/pages/components-demo/AdditionalComponentsDemo.tsx
+++ b/apps/web/src/pages/components-demo/AdditionalComponentsDemo.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { Btn } from '@/components/btn/Btn';
+import { Card } from '@/components/card/Card';
+import { DateInput } from '@/components/date-input/DateInput';
+import { Label } from '@/components/label/Label';
+import { SeamlessTextInput } from '@/components/seamless-text-input/SeamlessTextInput';
+import { SeamlessTextarea } from '@/components/seamless-textarea/SeamlessTextarea';
+import { Skeleton } from '@/components/skeleton/Skeleton';
+import { TextareaInput } from '@/components/textarea-input/TextareaInput';
+import { toastManager } from '@/components/toast/toastManager';
+import { UploadTileGrid } from '@/components/upload-tile-grid/UploadTileGrid';
+import css from './ComponentsDemoPage.module.css';
+
+/** Showcases the shared components added after the original catalog was created. */
+export function AdditionalComponentsDemo() {
+  const [files, setFiles] = useState<File[]>([]);
+
+  return (
+    <>
+      <section>
+        <h2>Labels and inputs</h2>
+        <div className={css.formGrid}>
+          <Label text='DateInput'>
+            <DateInput defaultValue='2026-08-08' />
+          </Label>
+          <Label text='TextareaInput'>
+            <TextareaInput defaultValue='A standard multiline field.' rows={3} />
+          </Label>
+        </div>
+      </section>
+
+      <section>
+        <h2>Seamless fields</h2>
+        <Card className={css.seamlessCard}>
+          <SeamlessTextInput aria-label='Demo seamless title' defaultValue='Editable card title' />
+          <SeamlessTextarea
+            aria-label='Demo seamless description'
+            defaultValue='These controls inherit the surrounding surface instead of drawing their own.'
+            rows={3}
+          />
+        </Card>
+      </section>
+
+      <section>
+        <h2>Skeleton</h2>
+        <Card className={css.skeletonCard}>
+          <Skeleton className={css.skeletonTitle} />
+          <Skeleton className={css.skeletonLine} />
+          <Skeleton className={css.skeletonShortLine} />
+        </Card>
+      </section>
+
+      <section>
+        <h2>Toast</h2>
+        <Btn
+          onClick={() =>
+            toastManager.add({
+              description: 'The global provider renders this notification.',
+              title: 'Demo toast',
+              type: 'success',
+            })
+          }
+          type='button'
+          variant='outlineMain'
+        >
+          Show toast
+        </Btn>
+      </section>
+
+      <section>
+        <h2>UploadTileGrid</h2>
+        <UploadTileGrid
+          files={files}
+          maxItemSize={5 * 1024 * 1024}
+          maxItems={4}
+          onFilesChange={setFiles}
+        />
+      </section>
+    </>
+  );
+}

--- a/apps/web/src/pages/components-demo/ComponentsDemoPage.module.css
+++ b/apps/web/src/pages/components-demo/ComponentsDemoPage.module.css
@@ -1,0 +1,82 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-lg);
+
+  & > h1 {
+    text-wrap: balance;
+  }
+
+  & > section {
+    display: grid;
+    width: 100%;
+    gap: var(--space-sm);
+  }
+}
+
+.loaderToggle {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  width: fit-content;
+}
+
+.cardRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+}
+
+.tableScroller {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.table {
+  display: grid;
+  align-items: center;
+  gap: var(--space-xs);
+  width: max-content;
+
+  & strong {
+    color: var(--c-muted-strong);
+  }
+}
+
+.tableRow {
+  display: contents;
+}
+
+.formGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+  gap: var(--space-md);
+}
+
+.seamlessCard {
+  display: grid;
+  max-width: 34rem;
+  gap: var(--space-xs);
+}
+
+.skeletonCard {
+  display: grid;
+  width: min(100%, 28rem);
+  gap: var(--space-sm);
+}
+
+.skeletonTitle {
+  width: 52%;
+  height: 1.5rem;
+}
+
+.skeletonLine {
+  width: 100%;
+  height: 0.875rem;
+}
+
+.skeletonShortLine {
+  width: 72%;
+  height: 0.875rem;
+}

--- a/apps/web/src/pages/components-demo/ComponentsDemoPage.tsx
+++ b/apps/web/src/pages/components-demo/ComponentsDemoPage.tsx
@@ -1,8 +1,6 @@
 import { PlusIcon, SearchIcon } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useState } from 'react';
-import { AppFrame } from '@/components/app-frame/AppFrame';
-import { AuthCard } from '@/components/auth-card/AuthCard';
 import { Btn, type BtnSize, type BtnVariant } from '@/components/btn/Btn';
 import { Card } from '@/components/card/Card';
 import { DefaultCatchBoundary } from '@/components/default-catch-boundary/DefaultCatchBoundary';
@@ -157,24 +155,8 @@ export function ComponentsDemoPage() {
       </section>
 
       <section>
-        <h2>AuthCard</h2>
-        <AuthCard
-          busy={false}
-          description='Continue with an invited Google account.'
-          error={null}
-          onGoogle={async () => {}}
-          title='Welcome back'
-        />
-      </section>
-
-      <section>
         <h2>NavMenu</h2>
         <NavMenu user={null} />
-      </section>
-
-      <section>
-        <h2>AppFrame</h2>
-        <AppFrame />
       </section>
 
       <section>

--- a/apps/web/src/pages/components-demo/ComponentsDemoPage.tsx
+++ b/apps/web/src/pages/components-demo/ComponentsDemoPage.tsx
@@ -1,0 +1,245 @@
+import { PlusIcon, SearchIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+import { AppFrame } from '@/components/app-frame/AppFrame';
+import { AuthCard } from '@/components/auth-card/AuthCard';
+import { Btn, type BtnSize, type BtnVariant } from '@/components/btn/Btn';
+import { Card } from '@/components/card/Card';
+import { DefaultCatchBoundary } from '@/components/default-catch-boundary/DefaultCatchBoundary';
+import { ErrorCard } from '@/components/error-card/ErrorCard';
+import { FloatingButton } from '@/components/floating-button/FloatingButton';
+import { NavMenu } from '@/components/nav-menu/NavMenu';
+import { NotFound } from '@/components/not-found/NotFound';
+import { NumberInput } from '@/components/number-input/NumberInput';
+import { SelectInput } from '@/components/select-input/SelectInput';
+import { TextInput } from '@/components/text-input/TextInput';
+import { AdditionalComponentsDemo } from './AdditionalComponentsDemo';
+import css from './ComponentsDemoPage.module.css';
+
+const SELECT_OPTIONS = [
+  { label: 'Less than or equal', value: 'lte' },
+  { label: 'More than or equal', value: 'gte' },
+] as const;
+
+const BTN_VARIANTS = [
+  { label: 'Main', value: 'main' },
+  { label: 'Danger', value: 'danger' },
+  { label: 'Outline main', value: 'outlineMain' },
+  { label: 'Outline danger', value: 'outlineDanger' },
+  { label: 'White', value: 'white' },
+  { label: 'Ghost', value: 'ghost' },
+  { label: 'Ghost danger', value: 'ghostDanger' },
+] satisfies DemoProp<BtnVariant>[];
+
+const BTN_SIZES = [
+  { label: 'Small', value: 'sm' },
+  { label: 'Medium', value: 'md' },
+  { label: 'Large', value: 'lg' },
+] satisfies DemoProp<BtnSize>[];
+
+type DemoProp<T extends string> = {
+  label: string;
+  value: T;
+};
+
+/** Renders the historical interactive catalog of the app's shared components. */
+export function ComponentsDemoPage() {
+  const [textValue, setTextValue] = useState('Smoky bowl');
+  const [numberValue, setNumberValue] = useState<number | null>(320);
+  const [selectValue, setSelectValue] = useState<(typeof SELECT_OPTIONS)[number]['value']>('lte');
+  const [btnLoading, setBtnLoading] = useState(false);
+
+  return (
+    <main className={css.page}>
+      <h1>Components</h1>
+
+      <section>
+        <h2>Btn</h2>
+        <label className={css.loaderToggle}>
+          <input
+            checked={btnLoading}
+            onChange={(event) => setBtnLoading(event.target.checked)}
+            type='checkbox'
+          />
+          Show loaders on buttons
+        </label>
+        <DemoTable
+          columns={BTN_SIZES}
+          renderCell={({ column, row }) => (
+            <Btn
+              icon={<PlusIcon aria-hidden='true' size={16} strokeWidth={1.8} />}
+              loading={btnLoading}
+              size={column.value}
+              variant={row.value}
+            >
+              {row.label}
+            </Btn>
+          )}
+          rows={BTN_VARIANTS}
+        />
+        <h3>Icon only</h3>
+        <DemoTable
+          columns={BTN_SIZES}
+          renderCell={({ column, row }) => (
+            <Btn
+              aria-label={`${row.label} ${column.label.toLowerCase()} icon button`}
+              icon={<SearchIcon aria-hidden='true' size={16} strokeWidth={1.8} />}
+              iconOnly
+              loading={btnLoading}
+              size={column.value}
+              variant={row.value}
+            />
+          )}
+          rows={BTN_VARIANTS}
+        />
+      </section>
+
+      <section>
+        <h2>Card</h2>
+        <div className={css.cardRow}>
+          <Card as='article'>Default card</Card>
+          <Card as='article' variant='primary'>
+            Primary card
+          </Card>
+          <Card as='article' variant='danger'>
+            Danger card
+          </Card>
+          <Card as='article' shadow={false}>
+            Card without shadow
+          </Card>
+        </div>
+      </section>
+
+      <section>
+        <h2>ErrorCard</h2>
+        <ErrorCard
+          message='Network request failed in this demo state.'
+          title='Could not fetch data'
+        />
+      </section>
+
+      <section>
+        <h2>TextInput</h2>
+        <TextInput
+          aria-label='Demo text input'
+          onValueChange={setTextValue}
+          placeholder='Search recipes'
+          type='search'
+          value={textValue}
+        />
+      </section>
+
+      <section>
+        <h2>NumberInput</h2>
+        <NumberInput
+          aria-label='Demo number input'
+          max={500}
+          min={0}
+          onValueChange={setNumberValue}
+          placeholder='Calories'
+          step={10}
+          value={numberValue}
+        />
+      </section>
+
+      <section>
+        <h2>SelectInput</h2>
+        <SelectInput
+          aria-label='Demo select input'
+          items={SELECT_OPTIONS}
+          onValueChange={(value) => {
+            if (value !== null) {
+              setSelectValue(value);
+            }
+          }}
+          value={selectValue}
+        />
+      </section>
+
+      <section>
+        <h2>AuthCard</h2>
+        <AuthCard
+          busy={false}
+          description='Continue with an invited Google account.'
+          error={null}
+          onGoogle={async () => {}}
+          title='Welcome back'
+        />
+      </section>
+
+      <section>
+        <h2>NavMenu</h2>
+        <NavMenu user={null} />
+      </section>
+
+      <section>
+        <h2>AppFrame</h2>
+        <AppFrame />
+      </section>
+
+      <section>
+        <h2>NotFound</h2>
+        <Card>
+          <NotFound />
+        </Card>
+      </section>
+
+      <section>
+        <h2>DefaultCatchBoundary</h2>
+        <Card>
+          <DefaultCatchBoundary
+            error={new Error('Demo boundary error')}
+            info={{ componentStack: '' }}
+            reset={() => {}}
+          />
+        </Card>
+      </section>
+
+      <section>
+        <h2>FloatingButton</h2>
+        <p>This component stays fixed to the viewport and is rendered once for this demo.</p>
+      </section>
+
+      <AdditionalComponentsDemo />
+
+      <FloatingButton
+        icon={<SearchIcon aria-hidden='true' size={18} strokeWidth={1.8} />}
+        to='/demo/components'
+      >
+        Floating action
+      </FloatingButton>
+    </main>
+  );
+}
+
+function DemoTable<RowValue extends string, ColumnValue extends string>({
+  columns,
+  renderCell,
+  rows,
+}: {
+  columns: DemoProp<ColumnValue>[];
+  renderCell: (props: { column: DemoProp<ColumnValue>; row: DemoProp<RowValue> }) => ReactNode;
+  rows: DemoProp<RowValue>[];
+}) {
+  return (
+    <div className={css.tableScroller}>
+      <div
+        className={css.table}
+        style={{ gridTemplateColumns: `8rem repeat(${columns.length}, max-content)` }}
+      >
+        <span aria-hidden='true' />
+        {columns.map((column) => (
+          <strong key={column.value}>{column.label}</strong>
+        ))}
+        {rows.map((row) => (
+          <div className={css.tableRow} key={row.value}>
+            <strong>{row.label}</strong>
+            {columns.map((column) => (
+              <div key={column.value}>{renderCell({ column, row })}</div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/components-demo/componentsDemo.test.ts
+++ b/apps/web/src/pages/components-demo/componentsDemo.test.ts
@@ -3,12 +3,15 @@ import { resolve } from 'node:path';
 import process from 'node:process';
 import { describe, expect, it } from 'vitest';
 
+// Skipped components are already visible throughout the app or are too large or impractical to
+// showcase meaningfully on the components demo page.
+const SKIPPED_COMPONENTS = new Set(['app-frame', 'auth-card']);
+
 describe('components demo', () => {
   it('showcases every shared component directory', async () => {
     const root = process.cwd();
     const demoSources: string[] = [];
     const missingComponents: string[] = [];
-
     for await (const demoFile of glob('src/pages/components-demo/*.tsx', { cwd: root })) {
       demoSources.push(await readFile(resolve(root, demoFile), 'utf8'));
     }
@@ -17,6 +20,10 @@ describe('components demo', () => {
 
     for await (const componentFile of glob('src/components/*/*.tsx', { cwd: root })) {
       const componentDirectory = componentFile.split('/').at(-2)!;
+
+      if (SKIPPED_COMPONENTS.has(componentDirectory)) {
+        continue;
+      }
 
       if (!demoSource.includes(`@/components/${componentDirectory}/`)) {
         missingComponents.push(componentDirectory);

--- a/apps/web/src/pages/components-demo/componentsDemo.test.ts
+++ b/apps/web/src/pages/components-demo/componentsDemo.test.ts
@@ -1,0 +1,28 @@
+import { glob, readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import process from 'node:process';
+import { describe, expect, it } from 'vitest';
+
+describe('components demo', () => {
+  it('showcases every shared component directory', async () => {
+    const root = process.cwd();
+    const demoSources: string[] = [];
+    const missingComponents: string[] = [];
+
+    for await (const demoFile of glob('src/pages/components-demo/*.tsx', { cwd: root })) {
+      demoSources.push(await readFile(resolve(root, demoFile), 'utf8'));
+    }
+
+    const demoSource = demoSources.join('\n');
+
+    for await (const componentFile of glob('src/components/*/*.tsx', { cwd: root })) {
+      const componentDirectory = componentFile.split('/').at(-2)!;
+
+      if (!demoSource.includes(`@/components/${componentDirectory}/`)) {
+        missingComponents.push(componentDirectory);
+      }
+    }
+
+    expect([...new Set(missingComponents)].sort()).toEqual([]);
+  });
+});

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as DemoComponentsRouteImport } from './routes/demo.components'
 import { Route as ApiHealthRouteImport } from './routes/api/health'
 import { Route as AuthenticatedWeightRouteImport } from './routes/_authenticated/weight'
 import { Route as AuthenticatedTodosRouteImport } from './routes/_authenticated/todos'
@@ -40,6 +41,11 @@ const AuthenticatedRoute = AuthenticatedRouteImport.update({
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DemoComponentsRoute = DemoComponentsRouteImport.update({
+  id: '/demo/components',
+  path: '/demo/components',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiHealthRoute = ApiHealthRouteImport.update({
@@ -130,6 +136,7 @@ export interface FileRoutesByFullPath {
   '/todos': typeof AuthenticatedTodosRoute
   '/weight': typeof AuthenticatedWeightRoute
   '/api/health': typeof ApiHealthRoute
+  '/demo/components': typeof DemoComponentsRoute
   '/diary/$id': typeof AuthenticatedDiaryIdRoute
   '/recipes/add': typeof AuthenticatedRecipesAddRoute
   '/weight/add': typeof AuthenticatedWeightAddRoute
@@ -149,6 +156,7 @@ export interface FileRoutesByTo {
   '/todos': typeof AuthenticatedTodosRoute
   '/weight': typeof AuthenticatedWeightRoute
   '/api/health': typeof ApiHealthRoute
+  '/demo/components': typeof DemoComponentsRoute
   '/diary/$id': typeof AuthenticatedDiaryIdRoute
   '/recipes/add': typeof AuthenticatedRecipesAddRoute
   '/weight/add': typeof AuthenticatedWeightAddRoute
@@ -170,6 +178,7 @@ export interface FileRoutesById {
   '/_authenticated/todos': typeof AuthenticatedTodosRoute
   '/_authenticated/weight': typeof AuthenticatedWeightRoute
   '/api/health': typeof ApiHealthRoute
+  '/demo/components': typeof DemoComponentsRoute
   '/_authenticated/diary/$id': typeof AuthenticatedDiaryIdRoute
   '/_authenticated/recipes/add': typeof AuthenticatedRecipesAddRoute
   '/_authenticated/weight_/add': typeof AuthenticatedWeightAddRoute
@@ -191,6 +200,7 @@ export interface FileRouteTypes {
     | '/todos'
     | '/weight'
     | '/api/health'
+    | '/demo/components'
     | '/diary/$id'
     | '/recipes/add'
     | '/weight/add'
@@ -210,6 +220,7 @@ export interface FileRouteTypes {
     | '/todos'
     | '/weight'
     | '/api/health'
+    | '/demo/components'
     | '/diary/$id'
     | '/recipes/add'
     | '/weight/add'
@@ -230,6 +241,7 @@ export interface FileRouteTypes {
     | '/_authenticated/todos'
     | '/_authenticated/weight'
     | '/api/health'
+    | '/demo/components'
     | '/_authenticated/diary/$id'
     | '/_authenticated/recipes/add'
     | '/_authenticated/weight_/add'
@@ -247,6 +259,7 @@ export interface RootRouteChildren {
   AuthenticatedRoute: typeof AuthenticatedRouteWithChildren
   LoginRoute: typeof LoginRoute
   ApiHealthRoute: typeof ApiHealthRoute
+  DemoComponentsRoute: typeof DemoComponentsRoute
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
   ApiDemoPingRoute: typeof ApiDemoPingRoute
 }
@@ -272,6 +285,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/demo/components': {
+      id: '/demo/components'
+      path: '/demo/components'
+      fullPath: '/demo/components'
+      preLoaderRoute: typeof DemoComponentsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/health': {
@@ -421,6 +441,7 @@ const rootRouteChildren: RootRouteChildren = {
   AuthenticatedRoute: AuthenticatedRouteWithChildren,
   LoginRoute: LoginRoute,
   ApiHealthRoute: ApiHealthRoute,
+  DemoComponentsRoute: DemoComponentsRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
   ApiDemoPingRoute: ApiDemoPingRoute,
 }

--- a/apps/web/src/routes/-ComponentsDemoLink.tsx
+++ b/apps/web/src/routes/-ComponentsDemoLink.tsx
@@ -1,0 +1,10 @@
+import { Link } from '@tanstack/react-router';
+import css from './root.module.css';
+
+export default function ComponentsDemoLink() {
+  return (
+    <Link className={css.demoLink} to='/demo/components'>
+      Components demo
+    </Link>
+  );
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -7,11 +7,11 @@ import { getSessionUser } from '@/lib/auth/session.api';
 import { clientEnv } from '@/lib/env/client';
 import resetCss from '@/styles/reset.css?url';
 import type { QueryClient } from '@tanstack/react-query';
-import { HeadContent, Link, Scripts, createRootRouteWithContext } from '@tanstack/react-router';
+import { HeadContent, Scripts, createRootRouteWithContext } from '@tanstack/react-router';
 import * as React from 'react';
-import css from './root.module.css';
 
 const isLocalhostApp = import.meta.env.DEV;
+const ComponentsDemoLink = React.lazy(() => import('./-ComponentsDemoLink'));
 
 const faviconLinks = isLocalhostApp
   ? [
@@ -75,11 +75,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         <HeadContent />
       </head>
       <body>
-        {isLocalhostApp ? (
-          <Link className={css.demoLink} to='/demo/components'>
-            Components demo
-          </Link>
-        ) : null}
+        {isLocalhostApp ? <ComponentsDemoLink /> : null}
         {children}
         {/* {import.meta.env.DEV ? (
           <>

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -7,8 +7,9 @@ import { getSessionUser } from '@/lib/auth/session.api';
 import { clientEnv } from '@/lib/env/client';
 import resetCss from '@/styles/reset.css?url';
 import type { QueryClient } from '@tanstack/react-query';
-import { HeadContent, Scripts, createRootRouteWithContext } from '@tanstack/react-router';
+import { HeadContent, Link, Scripts, createRootRouteWithContext } from '@tanstack/react-router';
 import * as React from 'react';
+import css from './root.module.css';
 
 const isLocalhostApp = import.meta.env.DEV;
 
@@ -74,6 +75,11 @@ function RootDocument({ children }: { children: React.ReactNode }) {
         <HeadContent />
       </head>
       <body>
+        {isLocalhostApp ? (
+          <Link className={css.demoLink} to='/demo/components'>
+            Components demo
+          </Link>
+        ) : null}
         {children}
         {/* {import.meta.env.DEV ? (
           <>

--- a/apps/web/src/routes/demo.components.tsx
+++ b/apps/web/src/routes/demo.components.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { ComponentsDemoPage } from '@/pages/components-demo/ComponentsDemoPage';
+
+export const Route = createFileRoute('/demo/components')({
+  component: ComponentsDemoPage,
+  head: () => ({ meta: [{ title: 'Components Demo' }] }),
+  staticData: {
+    navbar: {
+      label: 'Components',
+      upTo: { to: '/' },
+    },
+  },
+});

--- a/apps/web/src/routes/root.module.css
+++ b/apps/web/src/routes/root.module.css
@@ -1,0 +1,36 @@
+.demoLink {
+  position: fixed;
+  z-index: 100;
+  top: var(--space-xs);
+  left: 50%;
+  padding: 0.25rem 0.625rem;
+  border: 1px solid var(--c-border);
+  border-radius: 999px;
+  color: var(--c-muted-strong);
+  background: var(--c-surface);
+  font-size: var(--text-xs);
+  line-height: 1.25;
+  text-decoration: none;
+  transform: translateX(-50%);
+  transition:
+    color 140ms ease-out,
+    border-color 140ms ease-out,
+    background-color 140ms ease-out;
+
+  &:focus-visible {
+    outline: 2px solid var(--c-primary);
+    outline-offset: 2px;
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      color: var(--c-text);
+      border-color: var(--c-primary);
+      background: var(--c-surface-strong);
+    }
+  }
+
+  @media (--phone) {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- restore the component showcase at `/demo/components`
- add examples for every shared component directory and guard coverage with a test
- add a desktop-only development shortcut to the demo route

## Verification
- `pnpm check:fix`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Components Demo page showcasing shared UI elements, including buttons, forms, cards, navigation, loading states, notifications, and file uploads.
  - Added interactive examples for text, number, select, and loading controls.
  - Added a development-only link to access the Components Demo page.

- **Tests**
  - Added coverage to verify shared components are represented in the demo catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->