### PR TITLE
feat(calories): add barcode lookup [7/8]

### DIFF
--- a/apps/web/src/pages/calories/CaloriesPage.tsx
+++ b/apps/web/src/pages/calories/CaloriesPage.tsx
@@ -48,7 +48,8 @@ export function CaloriesPage({ dashboard, date }: CaloriesPageProps) {
           Scan barcode
         </Btn>
         <Btn
-          onClick={() => void navigate({ to: '/calories/quick-add', search: { date } })}
+          isLink
+          render={<Link search={{ date }} to='/calories/quick-add' />}
           variant='ghost'
         >
           Quick add

--- a/apps/web/src/pages/calories/CaloriesPage.tsx
+++ b/apps/web/src/pages/calories/CaloriesPage.tsx
@@ -47,7 +47,10 @@ export function CaloriesPage({ dashboard, date }: CaloriesPageProps) {
         >
           Scan barcode
         </Btn>
-        <Btn onClick={() => void navigate({ to: '/calories/quick-add', search: { date } })} variant='ghost'>
+        <Btn
+          onClick={() => void navigate({ to: '/calories/quick-add', search: { date } })}
+          variant='ghost'
+        >
           Quick add
         </Btn>
         <Btn

--- a/apps/web/src/pages/calories/CaloriesPage.tsx
+++ b/apps/web/src/pages/calories/CaloriesPage.tsx
@@ -42,9 +42,12 @@ export function CaloriesPage({ dashboard, date }: CaloriesPageProps) {
         </Btn>
         <Btn
           isLink
-          render={<Link search={{ date }} to='/calories/quick-add' />}
+          render={<Link search={{ date }} to='/calories/scan' />}
           variant='outlineMain'
         >
+          Scan barcode
+        </Btn>
+        <Btn onClick={() => void navigate({ to: '/calories/quick-add', search: { date } })} variant='ghost'>
           Quick add
         </Btn>
         <Btn

--- a/apps/web/src/pages/calories/ScanFoodPage.tsx
+++ b/apps/web/src/pages/calories/ScanFoodPage.tsx
@@ -5,14 +5,14 @@ import css from './CalorieFlows.module.css';
 import { todayLocalDate } from './calorieDate';
 import { lookupFoodByBarcode, recordFood, type CalorieFood } from './calories.api';
 
-export function ScanFoodPage() {
+export function ScanFoodPage({ initialDate }: { initialDate: string }) {
   const navigate = useNavigate();
   const lookingUp = useRef(false);
   const [barcode, setBarcode] = useState('');
   const [missing, setMissing] = useState('');
   const [food, setFood] = useState<CalorieFood | null>(null);
   const [grams, setGrams] = useState('100');
-  const [date, setDate] = useState(todayLocalDate());
+  const [date, setDate] = useState(initialDate);
 
   /** Looks up a typed barcode once and prepares the matching product for logging. */
   async function lookup() {
@@ -86,7 +86,7 @@ export function ScanFoodPage() {
               <span>{food.brand}</span>
               <p>
                 {food.kcalPer100g} kcal · {food.proteinPer100g ?? 0} g protein ·{' '}
-                {food.carbsPer100g ?? 0} g carbs · {food.fatPer100g ?? 0} g fat / 100 g
+                {food.fatPer100g ?? 0} g fat · {food.carbsPer100g ?? 0} g carbs / 100 g
               </p>
             </div>
           </section>

--- a/apps/web/src/pages/calories/ScanFoodPage.tsx
+++ b/apps/web/src/pages/calories/ScanFoodPage.tsx
@@ -1,0 +1,121 @@
+import { Link, useNavigate } from '@tanstack/react-router';
+import { useRef, useState } from 'react';
+import { Btn } from '@/components/btn/Btn';
+import css from './CalorieFlows.module.css';
+import { todayLocalDate } from './calorieDate';
+import { lookupFoodByBarcode, recordFood, type CalorieFood } from './calories.api';
+
+export function ScanFoodPage() {
+  const navigate = useNavigate();
+  const lookingUp = useRef(false);
+  const [barcode, setBarcode] = useState('');
+  const [missing, setMissing] = useState('');
+  const [food, setFood] = useState<CalorieFood | null>(null);
+  const [grams, setGrams] = useState('100');
+  const [date, setDate] = useState(todayLocalDate());
+
+  /** Looks up a typed barcode once and prepares the matching product for logging. */
+  async function lookup() {
+    const code = barcode.trim();
+    if (!code || lookingUp.current) return;
+    lookingUp.current = true;
+    setMissing('');
+    try {
+      const result = await lookupFoodByBarcode({ data: { barcode: code } });
+      if (result.status === 'found') {
+        setFood(result.food);
+        setGrams(String(result.food.productSizeGrams ?? 100));
+      } else {
+        setFood(null);
+        setMissing(code);
+      }
+    } finally {
+      lookingUp.current = false;
+    }
+  }
+
+  async function add() {
+    if (!food) return;
+    await recordFood({ data: { date, grams: Number(grams), productId: food.id } });
+    await navigate({ to: '/calories', search: { date } });
+  }
+
+  return (
+    <main className={css.page}>
+      <Link className={css.back} search={{ date }} to='/calories'>
+        ← Diary
+      </Link>
+      <header className={css.header}>
+        <div>
+          <h1>Look up barcode</h1>
+          <p>Enter the digits printed beneath the product barcode.</p>
+        </div>
+      </header>
+
+      {!food ? (
+        <section className={css.panel}>
+          <div className={css.barcodeInput}>
+            <input
+              aria-label='Enter barcode manually'
+              inputMode='numeric'
+              onChange={(event) => setBarcode(event.target.value)}
+              placeholder='Enter barcode'
+              value={barcode}
+            />
+            <Btn disabled={!barcode.trim()} onClick={() => void lookup()}>
+              Look up
+            </Btn>
+          </div>
+          {missing ? (
+            <div className={css.missingProduct}>
+              <strong>Barcode {missing} was not found</strong>
+              <div className={css.actions}>
+                <Link search={{ barcode: missing, date }} to='/calories/foods/new'>
+                  Create product
+                </Link>
+              </div>
+            </div>
+          ) : null}
+        </section>
+      ) : (
+        <>
+          <section className={css.productSummary}>
+            {food.imageUrl ? <img alt='' src={food.imageUrl} /> : null}
+            <div>
+              <strong>{food.name}</strong>
+              <span>{food.brand}</span>
+              <p>
+                {food.kcalPer100g} kcal · {food.proteinPer100g ?? 0} g protein ·{' '}
+                {food.carbsPer100g ?? 0} g carbs · {food.fatPer100g ?? 0} g fat / 100 g
+              </p>
+            </div>
+          </section>
+          <section className={css.panel}>
+            <div className={css.grid}>
+              <label className={css.field}>
+                <span>Quantity (g)</span>
+                <input
+                  min='0.01'
+                  onChange={(event) => setGrams(event.target.value)}
+                  step='0.01'
+                  type='number'
+                  value={grams}
+                />
+              </label>
+              <label className={css.field}>
+                <span>Date</span>
+                <input onChange={(event) => setDate(event.target.value)} type='date' value={date} />
+              </label>
+            </div>
+            <div className={css.actions}>
+              <Btn onClick={() => void add()}>Add to diary</Btn>
+              <Btn onClick={() => setFood(null)} variant='ghost'>
+                Look up another
+              </Btn>
+            </div>
+          </section>
+        </>
+      )}
+    </main>
+  );
+}

--- a/apps/web/src/pages/calories/ScanFoodPage.tsx
+++ b/apps/web/src/pages/calories/ScanFoodPage.tsx
@@ -1,8 +1,11 @@
 import { Link, useNavigate } from '@tanstack/react-router';
 import { useRef, useState } from 'react';
 import { Btn } from '@/components/btn/Btn';
+import { DateInput } from '@/components/date-input/DateInput';
+import { Label } from '@/components/label/Label';
+import { NumberInput } from '@/components/number-input/NumberInput';
+import { TextInput } from '@/components/text-input/TextInput';
 import css from './CalorieFlows.module.css';
-import { todayLocalDate } from './calorieDate';
 import { lookupFoodByBarcode, recordFood, type CalorieFood } from './calories.api';
 
 export function ScanFoodPage({ initialDate }: { initialDate: string }) {
@@ -11,7 +14,7 @@ export function ScanFoodPage({ initialDate }: { initialDate: string }) {
   const [barcode, setBarcode] = useState('');
   const [missing, setMissing] = useState('');
   const [food, setFood] = useState<CalorieFood | null>(null);
-  const [grams, setGrams] = useState('100');
+  const [grams, setGrams] = useState<number | null>(100);
   const [date, setDate] = useState(initialDate);
 
   /** Looks up a typed barcode once and prepares the matching product for logging. */
@@ -24,7 +27,7 @@ export function ScanFoodPage({ initialDate }: { initialDate: string }) {
       const result = await lookupFoodByBarcode({ data: { barcode: code } });
       if (result.status === 'found') {
         setFood(result.food);
-        setGrams(String(result.food.productSizeGrams ?? 100));
+        setGrams(result.food.productSizeGrams ?? 100);
       } else {
         setFood(null);
         setMissing(code);
@@ -36,15 +39,12 @@ export function ScanFoodPage({ initialDate }: { initialDate: string }) {
 
   async function add() {
     if (!food) return;
-    await recordFood({ data: { date, grams: Number(grams), productId: food.id } });
+    await recordFood({ data: { date, grams: grams ?? 0, productId: food.id } });
     await navigate({ to: '/calories', search: { date } });
   }
 
   return (
     <main className={css.page}>
-      <Link className={css.back} search={{ date }} to='/calories'>
-        ← Diary
-      </Link>
       <header className={css.header}>
         <div>
           <h1>Look up barcode</h1>
@@ -55,10 +55,10 @@ export function ScanFoodPage({ initialDate }: { initialDate: string }) {
       {!food ? (
         <section className={css.panel}>
           <div className={css.barcodeInput}>
-            <input
+            <TextInput
               aria-label='Enter barcode manually'
               inputMode='numeric'
-              onChange={(event) => setBarcode(event.target.value)}
+              onValueChange={setBarcode}
               placeholder='Enter barcode'
               value={barcode}
             />
@@ -70,9 +70,15 @@ export function ScanFoodPage({ initialDate }: { initialDate: string }) {
             <div className={css.missingProduct}>
               <strong>Barcode {missing} was not found</strong>
               <div className={css.actions}>
-                <Link search={{ barcode: missing, date }} to='/calories/foods/new'>
+                <Btn
+                  isLink
+                  render={
+                    <Link search={{ barcode: missing, date }} to='/calories/foods/new' />
+                  }
+                  variant='ghost'
+                >
                   Create product
-                </Link>
+                </Btn>
               </div>
             </div>
           ) : null}
@@ -92,20 +98,17 @@ export function ScanFoodPage({ initialDate }: { initialDate: string }) {
           </section>
           <section className={css.panel}>
             <div className={css.grid}>
-              <label className={css.field}>
-                <span>Quantity (g)</span>
-                <input
-                  min='0.01'
-                  onChange={(event) => setGrams(event.target.value)}
-                  step='0.01'
-                  type='number'
+              <Label text='Quantity (g)'>
+                <NumberInput
+                  min={0.01}
+                  onValueChange={setGrams}
+                  step={0.01}
                   value={grams}
                 />
-              </label>
-              <label className={css.field}>
-                <span>Date</span>
-                <input onChange={(event) => setDate(event.target.value)} type='date' value={date} />
-              </label>
+              </Label>
+              <Label text='Date'>
+                <DateInput onValueChange={setDate} value={date} />
+              </Label>
             </div>
             <div className={css.actions}>
               <Btn onClick={() => void add()}>Add to diary</Btn>

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -27,6 +27,7 @@ import { Route as AuthenticatedWeightImportRouteImport } from './routes/_authent
 import { Route as AuthenticatedWeightAddRouteImport } from './routes/_authenticated/weight_.add'
 import { Route as AuthenticatedRecipesAddRouteImport } from './routes/_authenticated/recipes/add'
 import { Route as AuthenticatedDiaryIdRouteImport } from './routes/_authenticated/diary/$id'
+import { Route as AuthenticatedCaloriesScanRouteImport } from './routes/_authenticated/calories_.scan'
 import { Route as AuthenticatedCaloriesQuickAddRouteImport } from './routes/_authenticated/calories_.quick-add'
 import { Route as AuthenticatedCaloriesGoalsRouteImport } from './routes/_authenticated/calories_.goals'
 import { Route as AuthenticatedCaloriesAddRouteImport } from './routes/_authenticated/calories_.add'
@@ -126,6 +127,12 @@ const AuthenticatedDiaryIdRoute = AuthenticatedDiaryIdRouteImport.update({
   path: '/diary/$id',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
+const AuthenticatedCaloriesScanRoute =
+  AuthenticatedCaloriesScanRouteImport.update({
+    id: '/calories_/scan',
+    path: '/calories/scan',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedCaloriesQuickAddRoute =
   AuthenticatedCaloriesQuickAddRouteImport.update({
     id: '/calories_/quick-add',
@@ -181,6 +188,7 @@ export interface FileRoutesByFullPath {
   '/calories/add': typeof AuthenticatedCaloriesAddRoute
   '/calories/goals': typeof AuthenticatedCaloriesGoalsRoute
   '/calories/quick-add': typeof AuthenticatedCaloriesQuickAddRoute
+  '/calories/scan': typeof AuthenticatedCaloriesScanRoute
   '/diary/$id': typeof AuthenticatedDiaryIdRoute
   '/recipes/add': typeof AuthenticatedRecipesAddRoute
   '/weight/add': typeof AuthenticatedWeightAddRoute
@@ -207,6 +215,7 @@ export interface FileRoutesByTo {
   '/calories/add': typeof AuthenticatedCaloriesAddRoute
   '/calories/goals': typeof AuthenticatedCaloriesGoalsRoute
   '/calories/quick-add': typeof AuthenticatedCaloriesQuickAddRoute
+  '/calories/scan': typeof AuthenticatedCaloriesScanRoute
   '/diary/$id': typeof AuthenticatedDiaryIdRoute
   '/recipes/add': typeof AuthenticatedRecipesAddRoute
   '/weight/add': typeof AuthenticatedWeightAddRoute
@@ -235,6 +244,7 @@ export interface FileRoutesById {
   '/_authenticated/calories_/add': typeof AuthenticatedCaloriesAddRoute
   '/_authenticated/calories_/goals': typeof AuthenticatedCaloriesGoalsRoute
   '/_authenticated/calories_/quick-add': typeof AuthenticatedCaloriesQuickAddRoute
+  '/_authenticated/calories_/scan': typeof AuthenticatedCaloriesScanRoute
   '/_authenticated/diary/$id': typeof AuthenticatedDiaryIdRoute
   '/_authenticated/recipes/add': typeof AuthenticatedRecipesAddRoute
   '/_authenticated/weight_/add': typeof AuthenticatedWeightAddRoute
@@ -263,6 +273,7 @@ export interface FileRouteTypes {
     | '/calories/add'
     | '/calories/goals'
     | '/calories/quick-add'
+    | '/calories/scan'
     | '/diary/$id'
     | '/recipes/add'
     | '/weight/add'
@@ -289,6 +300,7 @@ export interface FileRouteTypes {
     | '/calories/add'
     | '/calories/goals'
     | '/calories/quick-add'
+    | '/calories/scan'
     | '/diary/$id'
     | '/recipes/add'
     | '/weight/add'
@@ -316,6 +328,7 @@ export interface FileRouteTypes {
     | '/_authenticated/calories_/add'
     | '/_authenticated/calories_/goals'
     | '/_authenticated/calories_/quick-add'
+    | '/_authenticated/calories_/scan'
     | '/_authenticated/diary/$id'
     | '/_authenticated/recipes/add'
     | '/_authenticated/weight_/add'
@@ -470,6 +483,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedDiaryIdRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/calories_/scan': {
+      id: '/_authenticated/calories_/scan'
+      path: '/calories/scan'
+      fullPath: '/calories/scan'
+      preLoaderRoute: typeof AuthenticatedCaloriesScanRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/calories_/quick-add': {
       id: '/_authenticated/calories_/quick-add'
       path: '/calories/quick-add'
@@ -530,6 +550,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedCaloriesAddRoute: typeof AuthenticatedCaloriesAddRoute
   AuthenticatedCaloriesGoalsRoute: typeof AuthenticatedCaloriesGoalsRoute
   AuthenticatedCaloriesQuickAddRoute: typeof AuthenticatedCaloriesQuickAddRoute
+  AuthenticatedCaloriesScanRoute: typeof AuthenticatedCaloriesScanRoute
   AuthenticatedDiaryIdRoute: typeof AuthenticatedDiaryIdRoute
   AuthenticatedRecipesAddRoute: typeof AuthenticatedRecipesAddRoute
   AuthenticatedWeightAddRoute: typeof AuthenticatedWeightAddRoute
@@ -550,6 +571,7 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedCaloriesAddRoute: AuthenticatedCaloriesAddRoute,
   AuthenticatedCaloriesGoalsRoute: AuthenticatedCaloriesGoalsRoute,
   AuthenticatedCaloriesQuickAddRoute: AuthenticatedCaloriesQuickAddRoute,
+  AuthenticatedCaloriesScanRoute: AuthenticatedCaloriesScanRoute,
   AuthenticatedDiaryIdRoute: AuthenticatedDiaryIdRoute,
   AuthenticatedRecipesAddRoute: AuthenticatedRecipesAddRoute,
   AuthenticatedWeightAddRoute: AuthenticatedWeightAddRoute,

--- a/apps/web/src/routes/_authenticated/calories_.scan.tsx
+++ b/apps/web/src/routes/_authenticated/calories_.scan.tsx
@@ -2,10 +2,18 @@ import { type } from 'arktype';
 import { createFileRoute } from '@tanstack/react-router';
 import { ScanFoodPage } from '@/pages/calories/ScanFoodPage';
 import { normalizeCalorieDate } from '@/pages/calories/calorieDate';
+
 export const Route = createFileRoute('/_authenticated/calories_/scan')({
   validateSearch: type({ 'date?': 'string' }),
   component: Component,
+  staticData: {
+    navbar: {
+      label: 'Look up barcode',
+      upTo: { to: '/calories' },
+    },
+  },
 });
+
 function Component() {
   return <ScanFoodPage initialDate={normalizeCalorieDate(Route.useSearch().date)} />;
 }

--- a/apps/web/src/routes/_authenticated/calories_.scan.tsx
+++ b/apps/web/src/routes/_authenticated/calories_.scan.tsx
@@ -1,0 +1,10 @@
+import { type } from 'arktype';
+import { createFileRoute } from '@tanstack/react-router';
+import { ScanFoodPage } from '@/pages/calories/ScanFoodPage';
+export const Route = createFileRoute('/_authenticated/calories_/scan')({
+  validateSearch: type({ 'date?': 'string' }),
+  component: Component,
+});
+function Component() {
+  return <ScanFoodPage />;
+}

--- a/apps/web/src/routes/_authenticated/calories_.scan.tsx
+++ b/apps/web/src/routes/_authenticated/calories_.scan.tsx
@@ -1,10 +1,11 @@
 import { type } from 'arktype';
 import { createFileRoute } from '@tanstack/react-router';
 import { ScanFoodPage } from '@/pages/calories/ScanFoodPage';
+import { normalizeCalorieDate } from '@/pages/calories/calorieDate';
 export const Route = createFileRoute('/_authenticated/calories_/scan')({
   validateSearch: type({ 'date?': 'string' }),
   component: Component,
 });
 function Component() {
-  return <ScanFoodPage />;
+  return <ScanFoodPage initialDate={normalizeCalorieDate(Route.useSearch().date)} />;
 }

--- a/docs/calorie-pr-stack.md
+++ b/docs/calorie-pr-stack.md
@@ -46,3 +46,7 @@ The fifth PR adds forms for creating and editing global food products. Products 
 ## Logging catalog foods
 
 The sixth PR adds a searchable food picker. Selecting a product opens a serving form with quantity in grams and the diary date. Saving calculates calories and macronutrients from the product's per-100-gram values and stores the result as a new immutable diary snapshot.
+
+## Barcode lookup
+
+The seventh PR adds a manual barcode flow. A typed barcode first searches the Veles catalog, then requests and validates an Open Food Facts product when no local match exists. Valid external products are added to the shared catalog before logging. A missing product can be created manually with its barcode and diary date carried into the form.


### PR DESCRIPTION
Stack 7 of 8; based on the catalog-logging PR.

Adds the manual barcode lookup UI, missing-product handling, and logging matched products. It exercises the validated Open Food Facts import introduced with the data foundation; camera access is deliberately deferred to the next PR.

Replaces #81 after adopting the repository stack branch naming convention.
Reference implementation: #74