### PR TITLE
fix(web): redirect authenticated users from login

### DIFF
--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -1,9 +1,15 @@
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, redirect } from '@tanstack/react-router';
 import { type } from 'arktype';
 import { LoginPage, LoginPendingPage } from '@/pages/login/LoginPage';
+import { getSafeRedirectPath } from '@/lib/auth/getSafeRedirectPath';
 
 export const Route = createFileRoute('/login')({
   validateSearch: type({ 'redirect?': 'string' }),
+  beforeLoad: ({ context, search }) => {
+    if (context.user) {
+      throw redirect({ to: getSafeRedirectPath(search.redirect) });
+    }
+  },
   component: LoginPage,
   pendingComponent: LoginPendingPage,
   ssr: false,


### PR DESCRIPTION
## Summary
- redirect authenticated users away from `/login`
- preserve safe local redirect targets and default to `/`

## Verification
- `pnpm check:fix`
- opened `/login` in the running web app and confirmed the unauthenticated sign-in surface still renders