### PR TITLE
feat(calories): add responsive logging menu

### DIFF
--- a/apps/web/src/pages/calories/dashboard/CaloriesPage.module.css
+++ b/apps/web/src/pages/calories/dashboard/CaloriesPage.module.css
@@ -421,10 +421,10 @@ label small {
 .expandedDay {
   display: block;
 }
-.entryActions {
+.pageToolbar {
   display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-sm);
+  justify-content: end;
+  margin-bottom: calc(-1 * var(--space-sm));
 }
 
 @media (--phone) {

--- a/apps/web/src/pages/calories/dashboard/CaloriesPage.tsx
+++ b/apps/web/src/pages/calories/dashboard/CaloriesPage.tsx
@@ -1,13 +1,14 @@
 import { Toggle } from '@base-ui/react/toggle';
 import { ToggleGroup } from '@base-ui/react/toggle-group';
 import { useQueryClient } from '@tanstack/react-query';
-import { Link, useNavigate } from '@tanstack/react-router';
+import { useNavigate } from '@tanstack/react-router';
 import clsx from 'clsx';
 import { addDays, format, isAfter, parseISO } from 'date-fns';
 import { CheckIcon, ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
 import type { CalorieDashboard } from '../calories.api';
 import { calorieDashboardQueryOptions } from '../calorieQueries';
 import { CalorieOverview } from './CalorieOverview';
+import { LogFoodMenu } from './LogFoodMenu';
 import { CALORIE_DATE_FORMAT, calorieWeekDates, todayLocalDate } from '../calorieHelpers';
 import { Btn } from '@/components/btn/Btn';
 import css from './CaloriesPage.module.css';
@@ -36,6 +37,10 @@ export function CaloriesPage({ dashboard, date }: CaloriesPageProps) {
   }
   return (
     <main className={css.page}>
+      <div className={css.pageToolbar} data-appear>
+        <LogFoodMenu date={date} />
+      </div>
+
       <div className={css.dayStrip} data-appear>
         <Btn
           aria-label='Previous week'
@@ -104,24 +109,6 @@ export function CaloriesPage({ dashboard, date }: CaloriesPageProps) {
         logs={selectedDay.logs}
         totals={selectedDay.totals}
       />
-
-      <section aria-label='Diary actions' className={css.entryActions} data-appear='3'>
-        <Btn isLink render={<Link search={{ date }} to='/calories/add' />}>
-          Add food
-        </Btn>
-        <Btn isLink render={<Link search={{ date }} to='/calories/scan' />} variant='outlineMain'>
-          Scan barcode
-        </Btn>
-        <Btn isLink render={<Link search={{ date }} to='/calories/quick-add' />} variant='ghost'>
-          Quick add
-        </Btn>
-        <Btn isLink render={<Link search={{ date }} to='/calories/foods/new' />} variant='ghost'>
-          New food
-        </Btn>
-        <Btn isLink render={<Link to='/calories/goals' />} variant='ghost'>
-          Set daily goals
-        </Btn>
-      </section>
     </main>
   );
 }

--- a/apps/web/src/pages/calories/dashboard/LogFoodMenu.module.css
+++ b/apps/web/src/pages/calories/dashboard/LogFoodMenu.module.css
@@ -1,0 +1,163 @@
+.trigger {
+  margin-left: auto;
+}
+.chevron {
+  width: 1rem;
+  transition: transform var(--duration-fast) ease-in-out;
+}
+.trigger[data-popup-open] .chevron {
+  transform: rotate(180deg);
+}
+.positioner {
+  z-index: 30;
+  outline: none;
+}
+.popup {
+  display: grid;
+  width: min(23rem, calc(100vw - 2rem));
+  padding: var(--space-xs);
+  border: var(--border-width) solid var(--c-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--c-surface-raised);
+  box-shadow: var(--shadow-popup);
+  color: var(--c-text);
+  transform-origin: var(--transform-origin);
+}
+.popup[data-open] {
+  animation: menu-in 160ms ease-out;
+}
+.popup[data-closed] {
+  animation: menu-out 100ms ease-in-out;
+}
+.mobileHeading {
+  display: none;
+}
+.item {
+  display: grid;
+  grid-template-columns: 2.5rem minmax(0, 1fr);
+  align-items: center;
+  gap: var(--space-sm);
+  min-height: 3.5rem;
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: var(--radius-sm);
+  color: inherit;
+  text-decoration: none;
+  outline: none;
+  cursor: pointer;
+}
+.item[data-highlighted] {
+  background: var(--c-primary-surface);
+}
+.itemIcon {
+  display: grid;
+  place-items: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border: var(--border-width) solid var(--c-primary-border-soft);
+  border-radius: var(--radius-sm);
+  background: var(--c-primary-surface);
+  color: var(--c-accent);
+}
+.itemIcon svg {
+  width: 1.2rem;
+  height: 1.2rem;
+}
+.itemCopy {
+  display: grid;
+  gap: 0.1rem;
+  min-width: 0;
+}
+.itemCopy strong {
+  font-size: var(--text-sm);
+}
+.itemCopy > span {
+  overflow: hidden;
+  color: var(--c-muted);
+  font-size: var(--text-xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.separator {
+  height: var(--border-width);
+  margin: var(--space-xs) var(--space-sm);
+  background: var(--c-border);
+}
+@keyframes menu-in {
+  from {
+    opacity: 0;
+    transform: scale(0.97) translateY(-0.25rem);
+  }
+}
+@keyframes menu-out {
+  to {
+    opacity: 0;
+    transform: scale(0.98);
+  }
+}
+@media (--phone) {
+  .trigger {
+    position: fixed;
+    right: var(--space-md);
+    bottom: calc(4.75rem + env(safe-area-inset-bottom, 0px));
+    z-index: 20;
+    box-shadow: var(--shadow-card-primary);
+  }
+  .positioner {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: end;
+    width: 100%;
+    height: 100%;
+    padding: var(--space-sm);
+    background: color-mix(in srgb, var(--c-surface-inset) 75%, transparent);
+  }
+  .popup {
+    width: 100%;
+    max-height: calc(100dvh - 2rem);
+    padding: var(--space-sm);
+    border-radius: var(--radius-md);
+  }
+  .popup[data-open] {
+    animation-name: sheet-in;
+  }
+  .popup[data-closed] {
+    animation-name: sheet-out;
+  }
+  .mobileHeading {
+    display: grid;
+    gap: 0.15rem;
+    padding: var(--space-sm) var(--space-sm) var(--space-md);
+  }
+  .mobileHeading strong {
+    font-size: var(--text-lg);
+  }
+  .mobileHeading span {
+    color: var(--c-muted);
+    font-size: var(--text-sm);
+  }
+  .item {
+    min-height: 4rem;
+  }
+  @keyframes sheet-in {
+    from {
+      opacity: 0;
+      transform: translateY(1rem);
+    }
+  }
+  @keyframes sheet-out {
+    to {
+      opacity: 0;
+      transform: translateY(0.5rem);
+    }
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .popup[data-open],
+  .popup[data-closed] {
+    animation: none;
+  }
+  .chevron {
+    transition: none;
+  }
+}

--- a/apps/web/src/pages/calories/dashboard/LogFoodMenu.tsx
+++ b/apps/web/src/pages/calories/dashboard/LogFoodMenu.tsx
@@ -1,0 +1,84 @@
+import { Menu } from '@base-ui/react/menu';
+import { Link } from '@tanstack/react-router';
+import { BarcodeIcon, ChevronDownIcon, PlusIcon, ScanLineIcon, SparklesIcon } from 'lucide-react';
+import { Btn } from '@/components/btn/Btn';
+import css from './LogFoodMenu.module.css';
+
+type Props = { date: string };
+
+const loggingActions = [
+  {
+    description: 'Search your foods and choose a serving',
+    icon: PlusIcon,
+    label: 'Add food',
+    to: '/calories/add' as const,
+  },
+  {
+    description: 'Use the camera or enter a barcode',
+    icon: ScanLineIcon,
+    label: 'Scan barcode',
+    to: '/calories/scan' as const,
+  },
+  {
+    description: 'Enter calories and macros directly',
+    icon: SparklesIcon,
+    label: 'Quick add',
+    to: '/calories/quick-add' as const,
+  },
+];
+
+export function LogFoodMenu({ date }: Props) {
+  return (
+    <Menu.Root>
+      <Menu.Trigger
+        render={
+          <Btn className={css.trigger} icon={<PlusIcon aria-hidden='true' />} radius='pill' />
+        }
+      >
+        Log food
+        <ChevronDownIcon aria-hidden='true' className={css.chevron} />
+      </Menu.Trigger>
+      <Menu.Portal>
+        <Menu.Positioner align='end' className={css.positioner} sideOffset={8}>
+          <Menu.Popup aria-label='Log food' className={css.popup}>
+            <div className={css.mobileHeading}>
+              <strong>Log food</strong>
+              <span>Choose how you want to add this entry.</span>
+            </div>
+            {loggingActions.map((action) => {
+              const ActionIcon = action.icon;
+              return (
+                <Menu.Item
+                  className={css.item}
+                  key={action.to}
+                  render={<Link search={{ date }} to={action.to} />}
+                >
+                  <span className={css.itemIcon}>
+                    <ActionIcon aria-hidden='true' />
+                  </span>
+                  <span className={css.itemCopy}>
+                    <strong>{action.label}</strong>
+                    <span>{action.description}</span>
+                  </span>
+                </Menu.Item>
+              );
+            })}
+            <Menu.Separator className={css.separator} />
+            <Menu.Item
+              className={css.item}
+              render={<Link search={{ date }} to='/calories/foods/new' />}
+            >
+              <span className={css.itemIcon}>
+                <BarcodeIcon aria-hidden='true' />
+              </span>
+              <span className={css.itemCopy}>
+                <strong>Create a new food</strong>
+                <span>Save nutrition details for reuse</span>
+              </span>
+            </Menu.Item>
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
+  );
+}


### PR DESCRIPTION
## What changed
- replaces the five-button diary action row with one accessible Log food menu
- groups add, barcode scan, quick add, and food creation by intent
- presents an anchored popover on larger screens and a bottom-sheet-style surface on phones
- keeps the selected diary date in every logging route

## Verification
- `pnpm check:fix`
- 13 test files passed; 39 tests passed