### PR TITLE
feat(calories): place goal editing in summary

### DIFF
--- a/apps/web/src/pages/calories/dashboard/DailySummary.module.css
+++ b/apps/web/src/pages/calories/dashboard/DailySummary.module.css
@@ -25,6 +25,13 @@
     radial-gradient(circle at 100% 110%, rgba(167, 227, 161, 0.08), transparent 44%),
     linear-gradient(145deg, rgba(15, 23, 42, 0.7), var(--c-surface-inset));
 }
+.goalAction {
+  position: absolute;
+  top: var(--space-xs);
+  right: var(--space-xs);
+  z-index: 1;
+  color: var(--c-muted);
+}
 
 .energyDial {
   position: relative;

--- a/apps/web/src/pages/calories/dashboard/DailySummary.tsx
+++ b/apps/web/src/pages/calories/dashboard/DailySummary.tsx
@@ -1,3 +1,6 @@
+import { Link } from '@tanstack/react-router';
+import { GoalIcon } from 'lucide-react';
+import { Btn } from '@/components/btn/Btn';
 import { useId, useState } from 'react';
 import type { CalorieGoal, CalorieTotals } from '../calories.api';
 import { formatNutritionNumber } from './nutritionFormat';
@@ -20,6 +23,16 @@ export function DailySummary({ goal, totals }: DailySummaryProps) {
     <section aria-label='Daily nutrition summary' className={css.summary} data-appear='1'>
       <div className={css.body}>
         <div className={css.energyPanel}>
+          <Btn
+            className={css.goalAction}
+            icon={<GoalIcon aria-hidden='true' />}
+            isLink
+            render={<Link to='/calories/goals' />}
+            size='sm'
+            variant='ghost'
+          >
+            {goal ? 'Edit goals' : 'Set goals'}
+          </Btn>
           <EnergyDial
             goal={goal?.kcal}
             progress={energyProgress}


### PR DESCRIPTION
## What changed
- adds a contextual Set goals / Edit goals action inside the daily energy summary
- removes goal configuration from the food logging action group

## Verification
- `pnpm check:fix`
- 13 test files passed; 39 tests passed