### PR TITLE
feat(calories): improve diary logging actions

### DIFF
--- a/apps/web/src/components/floating-button/FloatingButton.tsx
+++ b/apps/web/src/components/floating-button/FloatingButton.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@tanstack/react-router';
-import type { ReactNode } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
 import { Btn } from '@/components/btn/Btn';
 import css from './FloatingButton.module.css';
 
@@ -7,8 +7,14 @@ type FloatingButtonProps = {
   children: ReactNode;
   icon?: ReactNode;
 } & (
-  | { loading?: never; onClick?: never; to: string }
-  | { loading?: boolean; onClick: () => void; to?: never }
+  | { loading?: never; onClick?: never; render?: never; to: string }
+  | { loading?: boolean; onClick: () => void; render?: never; to?: never }
+  | {
+      loading?: boolean;
+      onClick?: never;
+      render: ComponentProps<typeof Btn>['render'];
+      to?: never;
+    }
 );
 
 export function FloatingButton(props: FloatingButtonProps) {
@@ -22,6 +28,23 @@ export function FloatingButton(props: FloatingButtonProps) {
         isLink
         radius='pill'
         render={<Link to={props.to} />}
+        size='md'
+        variant='main'
+      >
+        {props.children}
+      </Btn>
+    );
+  }
+
+  if (props.render) {
+    return (
+      <Btn
+        aria-label={typeof props.children === 'string' ? props.children : undefined}
+        className={css.button}
+        icon={props.icon}
+        loading={props.loading}
+        radius='pill'
+        render={props.render}
         size='md'
         variant='main'
       >

--- a/apps/web/src/components/menu-btn/MenuBtn.module.css
+++ b/apps/web/src/components/menu-btn/MenuBtn.module.css
@@ -1,37 +1,46 @@
-.trigger {
-  margin-left: auto;
-}
 .chevron {
   width: 1rem;
   transition: transform var(--duration-fast) ease-in-out;
 }
+
 .trigger[data-popup-open] .chevron {
   transform: rotate(180deg);
 }
+
+.backdrop {
+  display: none;
+}
+
 .positioner {
   z-index: 30;
   outline: none;
 }
+
 .popup {
   display: grid;
   width: min(23rem, calc(100vw - 2rem));
   padding: var(--space-xs);
   border: var(--border-width) solid var(--c-border-strong);
   border-radius: var(--radius-md);
-  background: var(--c-surface-raised);
+  background: color-mix(in srgb, var(--c-surface-raised) 92%, transparent);
+  backdrop-filter: var(--blur-surface);
   box-shadow: var(--shadow-popup);
   color: var(--c-text);
   transform-origin: var(--transform-origin);
 }
+
 .popup[data-open] {
   animation: menu-in 160ms ease-out;
 }
+
 .popup[data-closed] {
   animation: menu-out 100ms ease-in-out;
 }
+
 .mobileHeading {
   display: none;
 }
+
 .item {
   display: grid;
   grid-template-columns: 2.5rem minmax(0, 1fr);
@@ -45,9 +54,11 @@
   outline: none;
   cursor: pointer;
 }
+
 .item[data-highlighted] {
   background: var(--c-primary-surface);
 }
+
 .itemIcon {
   display: grid;
   place-items: center;
@@ -58,18 +69,22 @@
   background: var(--c-primary-surface);
   color: var(--c-accent);
 }
+
 .itemIcon svg {
   width: 1.2rem;
   height: 1.2rem;
 }
+
 .itemCopy {
   display: grid;
   gap: 0.1rem;
   min-width: 0;
 }
+
 .itemCopy strong {
   font-size: var(--text-sm);
 }
+
 .itemCopy > span {
   overflow: hidden;
   color: var(--c-muted);
@@ -77,74 +92,90 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.separator {
+
+.divider {
   height: var(--border-width);
   margin: var(--space-xs) var(--space-sm);
   background: var(--c-border);
 }
+
 @keyframes menu-in {
   from {
     opacity: 0;
     transform: scale(0.97) translateY(-0.25rem);
   }
 }
+
 @keyframes menu-out {
   to {
     opacity: 0;
     transform: scale(0.98);
   }
 }
+
 @media (--phone) {
-  .trigger {
-    position: fixed;
-    right: var(--space-md);
-    bottom: calc(4.75rem + env(safe-area-inset-bottom, 0px));
-    z-index: 20;
-    box-shadow: var(--shadow-card-primary);
-  }
-  .positioner {
+  .backdrop {
     position: fixed;
     inset: 0;
-    display: flex;
-    align-items: end;
-    width: 100%;
-    height: 100%;
-    padding: var(--space-sm);
+    z-index: 30;
+    display: block;
     background: color-mix(in srgb, var(--c-surface-inset) 75%, transparent);
   }
+
+  .positioner {
+    position: fixed !important;
+    inset: auto var(--space-sm) max(var(--space-sm), env(safe-area-inset-bottom, 0px)) !important;
+    z-index: 31;
+    width: auto !important;
+    height: auto !important;
+    pointer-events: none;
+    transform: none !important;
+  }
+
   .popup {
     width: 100%;
-    max-height: calc(100dvh - 2rem);
+    max-height: calc(100dvh - var(--space-sm) - var(--space-sm) - env(safe-area-inset-bottom, 0px));
+    overflow-y: auto;
+    overscroll-behavior: contain;
     padding: var(--space-sm);
     border-radius: var(--radius-md);
+    pointer-events: auto;
   }
+
   .popup[data-open] {
     animation-name: sheet-in;
   }
+
   .popup[data-closed] {
     animation-name: sheet-out;
   }
+
   .mobileHeading {
     display: grid;
     gap: 0.15rem;
     padding: var(--space-sm) var(--space-sm) var(--space-md);
   }
+
   .mobileHeading strong {
     font-size: var(--text-lg);
   }
+
   .mobileHeading span {
     color: var(--c-muted);
     font-size: var(--text-sm);
   }
+
   .item {
     min-height: 4rem;
   }
+
   @keyframes sheet-in {
     from {
       opacity: 0;
       transform: translateY(1rem);
     }
   }
+
   @keyframes sheet-out {
     to {
       opacity: 0;
@@ -152,11 +183,13 @@
     }
   }
 }
+
 @media (prefers-reduced-motion: reduce) {
   .popup[data-open],
   .popup[data-closed] {
     animation: none;
   }
+
   .chevron {
     transition: none;
   }

--- a/apps/web/src/components/menu-btn/MenuBtn.tsx
+++ b/apps/web/src/components/menu-btn/MenuBtn.tsx
@@ -1,0 +1,86 @@
+import { Menu } from '@base-ui/react/menu';
+import clsx from 'clsx';
+import { ChevronDownIcon } from 'lucide-react';
+import { forwardRef, type ComponentPropsWithoutRef, type ReactNode } from 'react';
+import css from './MenuBtn.module.css';
+
+export const MenuBtnRoot = Menu.Root;
+
+type MenuBtnProps = ComponentPropsWithoutRef<typeof Menu.Trigger>;
+
+/** Composes Base UI's menu trigger into reusable buttons such as Btn and FloatingButton. */
+export const MenuBtn = forwardRef<HTMLButtonElement, MenuBtnProps>(function MenuBtn(
+  { className, ...props },
+  ref,
+) {
+  return <Menu.Trigger className={clsx(css.trigger, className)} ref={ref} {...props} />;
+});
+
+export function MenuBtnChevron({
+  className,
+  ...props
+}: ComponentPropsWithoutRef<typeof ChevronDownIcon>) {
+  return <ChevronDownIcon aria-hidden='true' className={clsx(css.chevron, className)} {...props} />;
+}
+
+type MenuBtnPopupProps = Omit<ComponentPropsWithoutRef<typeof Menu.Popup>, 'children'> & {
+  children: ReactNode;
+  description?: ReactNode;
+  heading?: ReactNode;
+  positionerProps?: Omit<
+    ComponentPropsWithoutRef<typeof Menu.Positioner>,
+    'children' | 'className'
+  >;
+};
+
+/** Renders the shared anchored popover and mobile bottom-sheet presentation. */
+export function MenuBtnPopup({
+  children,
+  className,
+  description,
+  heading,
+  positionerProps,
+  ...props
+}: MenuBtnPopupProps) {
+  return (
+    <Menu.Portal>
+      <Menu.Backdrop className={css.backdrop} />
+      <Menu.Positioner align='end' className={css.positioner} sideOffset={8} {...positionerProps}>
+        <Menu.Popup className={clsx(css.popup, className)} {...props}>
+          {heading || description ? (
+            <div className={css.mobileHeading}>
+              {heading ? <strong>{heading}</strong> : null}
+              {description ? <span>{description}</span> : null}
+            </div>
+          ) : null}
+          {children}
+        </Menu.Popup>
+      </Menu.Positioner>
+    </Menu.Portal>
+  );
+}
+
+type MenuBtnItemProps = Omit<ComponentPropsWithoutRef<typeof Menu.Item>, 'children'> & {
+  description?: ReactNode;
+  icon: ReactNode;
+  label: ReactNode;
+};
+
+export function MenuBtnItem({ className, description, icon, label, ...props }: MenuBtnItemProps) {
+  return (
+    <Menu.Item className={clsx(css.item, className)} {...props}>
+      <span className={css.itemIcon}>{icon}</span>
+      <span className={css.itemCopy}>
+        <strong>{label}</strong>
+        {description ? <span>{description}</span> : null}
+      </span>
+    </Menu.Item>
+  );
+}
+
+export function MenuBtnDivider({
+  className,
+  ...props
+}: ComponentPropsWithoutRef<typeof Menu.Separator>) {
+  return <Menu.Separator className={clsx(css.divider, className)} {...props} />;
+}

--- a/apps/web/src/components/menu-btn/MenuBtn.tsx
+++ b/apps/web/src/components/menu-btn/MenuBtn.tsx
@@ -1,20 +1,17 @@
 import { Menu } from '@base-ui/react/menu';
 import clsx from 'clsx';
 import { ChevronDownIcon } from 'lucide-react';
-import { forwardRef, type ComponentPropsWithoutRef, type ReactNode } from 'react';
+import type { ComponentPropsWithRef, ComponentPropsWithoutRef, ReactNode } from 'react';
 import css from './MenuBtn.module.css';
 
 export const MenuBtnRoot = Menu.Root;
 
-type MenuBtnProps = ComponentPropsWithoutRef<typeof Menu.Trigger>;
+type MenuBtnProps = ComponentPropsWithRef<typeof Menu.Trigger>;
 
 /** Composes Base UI's menu trigger into reusable buttons such as Btn and FloatingButton. */
-export const MenuBtn = forwardRef<HTMLButtonElement, MenuBtnProps>(function MenuBtn(
-  { className, ...props },
-  ref,
-) {
-  return <Menu.Trigger className={clsx(css.trigger, className)} ref={ref} {...props} />;
-});
+export function MenuBtn({ className, ...props }: MenuBtnProps) {
+  return <Menu.Trigger className={clsx(css.trigger, className)} {...props} />;
+}
 
 export function MenuBtnChevron({
   className,

--- a/apps/web/src/components/navbar/MobileNavbar.module.css
+++ b/apps/web/src/components/navbar/MobileNavbar.module.css
@@ -15,7 +15,7 @@
   border: 1px solid rgba(148, 163, 184, 0.26);
   border-radius: calc(var(--radius-pill) - 2px);
   background: rgba(15, 23, 42, 0.82);
-  backdrop-filter: var(--blur-navigation);
+  backdrop-filter: var(--blur-surface);
   box-shadow: 0 18px 48px rgba(2, 6, 23, 0.42);
 }
 

--- a/apps/web/src/components/navbar/MobileNavbar.module.css
+++ b/apps/web/src/components/navbar/MobileNavbar.module.css
@@ -15,7 +15,7 @@
   border: 1px solid rgba(148, 163, 184, 0.26);
   border-radius: calc(var(--radius-pill) - 2px);
   background: rgba(15, 23, 42, 0.82);
-  backdrop-filter: blur(22px);
+  backdrop-filter: var(--blur-navigation);
   box-shadow: 0 18px 48px rgba(2, 6, 23, 0.42);
 }
 

--- a/apps/web/src/components/upload-tile-grid/UploadTileGrid.module.css
+++ b/apps/web/src/components/upload-tile-grid/UploadTileGrid.module.css
@@ -64,7 +64,7 @@
   padding: 0.25rem 0.45rem;
   border-radius: 999px;
   background: rgba(15, 23, 42, 0.5);
-  backdrop-filter: var(--blur-image-overlay);
+  backdrop-filter: var(--blur-surface);
   color: white;
   font-size: 0.68rem;
   line-height: 1.2;

--- a/apps/web/src/components/upload-tile-grid/UploadTileGrid.module.css
+++ b/apps/web/src/components/upload-tile-grid/UploadTileGrid.module.css
@@ -64,7 +64,7 @@
   padding: 0.25rem 0.45rem;
   border-radius: 999px;
   background: rgba(15, 23, 42, 0.5);
-  backdrop-filter: blur(8px);
+  backdrop-filter: var(--blur-image-overlay);
   color: white;
   font-size: 0.68rem;
   line-height: 1.2;

--- a/apps/web/src/pages/calories/CalorieFlows.module.css
+++ b/apps/web/src/pages/calories/CalorieFlows.module.css
@@ -7,21 +7,25 @@
   gap: 1.25rem;
   padding-bottom: 5rem;
 }
+
 .header {
   display: flex;
   gap: 1rem;
   align-items: flex-start;
   justify-content: space-between;
 }
+
 .header h1 {
   font-size: clamp(1.75rem, 5vw, 2.5rem);
   text-wrap: balance;
 }
+
 .header p,
 .muted {
   color: var(--c-muted);
   text-wrap: pretty;
 }
+
 .panel {
   border: 1px solid var(--c-border);
   border-radius: 1rem;
@@ -30,18 +34,22 @@
   display: grid;
   gap: 1rem;
 }
+
 .form {
   display: grid;
   gap: 1rem;
 }
+
 .field {
   display: grid;
   gap: 0.35rem;
   font-weight: 600;
 }
+
 .field span {
   font-size: 0.875rem;
 }
+
 .field input {
   min-height: 44px;
   border: 1px solid var(--c-border);
@@ -51,25 +59,30 @@
   padding: 0.7rem 0.8rem;
   font: inherit;
 }
+
 .field input:focus-visible {
   outline: 2px solid var(--c-primary-focus);
   outline-offset: 2px;
 }
+
 .grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.8rem;
 }
+
 .actions {
   display: flex;
   flex-wrap: wrap;
   gap: 0.7rem;
 }
+
 .results {
   display: grid;
   gap: 0.6rem;
   list-style: none;
 }
+
 .result {
   width: 100%;
   min-height: 56px;
@@ -85,24 +98,30 @@
   align-items: center;
   cursor: pointer;
 }
+
 .result strong,
 .result span {
   display: block;
 }
+
 .result span {
   color: var(--c-muted);
   font-size: 0.875rem;
 }
+
 .error {
   color: var(--c-danger-text, #b42318);
 }
+
 .success {
   color: var(--c-macro-carb, #087443);
 }
+
 .scanner {
   display: grid;
   gap: 1rem;
 }
+
 .scanViewport {
   position: fixed;
   z-index: 20;
@@ -110,10 +129,12 @@
   background: #020617;
   padding: var(--space-sm);
 }
+
 .scanViewport > section {
   height: 100%;
   grid-template-rows: auto 1fr auto;
 }
+
 .scanBottom {
   position: absolute;
   z-index: 3;
@@ -123,6 +144,7 @@
   display: grid;
   gap: var(--space-sm);
 }
+
 .barcodeInput,
 .missingProduct {
   display: flex;
@@ -133,6 +155,7 @@
   border-radius: var(--radius-sm);
   background: var(--c-surface-solid);
 }
+
 .barcodeInput input {
   min-width: 0;
   min-height: 44px;
@@ -142,16 +165,19 @@
   color: inherit;
   font: inherit;
 }
+
 .missingProduct {
   align-items: stretch;
   flex-direction: column;
 }
+
 .missingProduct a {
   min-height: 44px;
   display: inline-flex;
   align-items: center;
   color: var(--c-text);
 }
+
 .productSummary {
   display: grid;
   grid-template-columns: 7rem 1fr;
@@ -161,12 +187,14 @@
   border-radius: var(--radius-sm);
   background: var(--c-surface);
 }
+
 .productSummary img {
   width: 7rem;
   height: 7rem;
   border-radius: var(--radius-xs);
   object-fit: cover;
 }
+
 .productSummary span,
 .productSummary p {
   display: block;
@@ -176,6 +204,7 @@
   .grid {
     grid-template-columns: 1fr;
   }
+
   .header {
     display: grid;
   }

--- a/apps/web/src/pages/calories/add/AddFoodPage.module.css
+++ b/apps/web/src/pages/calories/add/AddFoodPage.module.css
@@ -188,9 +188,11 @@
 .dotProtein {
   background: var(--c-macro-protein);
 }
+
 .dotFat {
   background: var(--c-macro-fat);
 }
+
 .dotCarbs {
   background: var(--c-macro-carb);
 }
@@ -211,16 +213,20 @@
   .energyTile {
     display: none;
   }
+
   .energyInline {
     display: flex;
   }
+
   .productName {
     font-size: var(--text-md-dynamic);
   }
+
   .grams,
   .energyInline span {
     font-size: var(--text-xs);
   }
+
   .energyInline strong {
     font-size: var(--text-md-dynamic);
   }

--- a/apps/web/src/pages/calories/dashboard/CalorieOverview.tsx
+++ b/apps/web/src/pages/calories/dashboard/CalorieOverview.tsx
@@ -1,3 +1,6 @@
+import { Link } from '@tanstack/react-router';
+import { PlusIcon } from 'lucide-react';
+import { Btn } from '@/components/btn/Btn';
 import type { CalorieGoal, CalorieLog, CalorieTotals } from '../calories.api';
 import { DailySummary } from './DailySummary';
 import { LoggedFood } from './LoggedFood';
@@ -26,7 +29,35 @@ export function CalorieOverview({ date, goal, logs, totals }: Props) {
             ))}
           </ol>
         ) : (
-          <p className={css.emptyLog}>Nothing logged for this day.</p>
+          <div className={css.emptyLog}>
+            <div>
+              <strong>Nothing logged for this day</strong>
+              <span>Start with a saved food, scan a package, or enter the totals directly.</span>
+            </div>
+            <div className={css.emptyActions}>
+              <Btn
+                icon={<PlusIcon aria-hidden='true' />}
+                isLink
+                render={<Link search={{ date }} to='/calories/add' />}
+              >
+                Add your first food
+              </Btn>
+              <Btn
+                isLink
+                render={<Link search={{ date }} to='/calories/scan' />}
+                variant='outlineMain'
+              >
+                Scan barcode
+              </Btn>
+              <Btn
+                isLink
+                render={<Link search={{ date }} to='/calories/quick-add' />}
+                variant='ghost'
+              >
+                Quick add
+              </Btn>
+            </div>
+          </div>
         )}
       </section>
     </div>

--- a/apps/web/src/pages/calories/dashboard/CalorieOverview.tsx
+++ b/apps/web/src/pages/calories/dashboard/CalorieOverview.tsx
@@ -26,12 +26,7 @@ export function CalorieOverview({ date, goal, logs, totals }: Props) {
             ))}
           </ol>
         ) : (
-          <div className={css.emptyLog}>
-            <div>
-              <strong>Nothing logged for this day</strong>
-              <span>Start with a saved food, scan a package, or enter the totals directly.</span>
-            </div>
-          </div>
+          <p className={css.emptyLog}>Nothing logged for this day</p>
         )}
       </section>
     </div>

--- a/apps/web/src/pages/calories/dashboard/CalorieOverview.tsx
+++ b/apps/web/src/pages/calories/dashboard/CalorieOverview.tsx
@@ -1,6 +1,3 @@
-import { Link } from '@tanstack/react-router';
-import { PlusIcon } from 'lucide-react';
-import { Btn } from '@/components/btn/Btn';
 import type { CalorieGoal, CalorieLog, CalorieTotals } from '../calories.api';
 import { DailySummary } from './DailySummary';
 import { LoggedFood } from './LoggedFood';
@@ -33,29 +30,6 @@ export function CalorieOverview({ date, goal, logs, totals }: Props) {
             <div>
               <strong>Nothing logged for this day</strong>
               <span>Start with a saved food, scan a package, or enter the totals directly.</span>
-            </div>
-            <div className={css.emptyActions}>
-              <Btn
-                icon={<PlusIcon aria-hidden='true' />}
-                isLink
-                render={<Link search={{ date }} to='/calories/add' />}
-              >
-                Add your first food
-              </Btn>
-              <Btn
-                isLink
-                render={<Link search={{ date }} to='/calories/scan' />}
-                variant='outlineMain'
-              >
-                Scan barcode
-              </Btn>
-              <Btn
-                isLink
-                render={<Link search={{ date }} to='/calories/quick-add' />}
-                variant='ghost'
-              >
-                Quick add
-              </Btn>
             </div>
           </div>
         )}

--- a/apps/web/src/pages/calories/dashboard/CaloriesPage.module.css
+++ b/apps/web/src/pages/calories/dashboard/CaloriesPage.module.css
@@ -231,13 +231,6 @@ label > span {
   text-wrap: pretty;
 }
 
-.emptyActions {
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: var(--space-xs);
-}
-
 .logList {
   display: grid;
   gap: var(--space-sm);

--- a/apps/web/src/pages/calories/dashboard/CaloriesPage.module.css
+++ b/apps/web/src/pages/calories/dashboard/CaloriesPage.module.css
@@ -206,28 +206,10 @@ label > span {
 }
 
 .emptyLog {
-  display: grid;
-  justify-items: center;
-  gap: var(--space-lg);
-  padding: clamp(var(--space-xl), 8vw, 4rem) var(--space-md);
-  border: var(--border-width) dashed var(--c-border-strong);
-  border-radius: var(--radius-sm);
-  text-align: center;
-}
-
-.emptyLog > div:first-child {
-  display: grid;
-  gap: var(--space-xs);
-  max-width: 32rem;
-}
-
-.emptyLog strong {
-  font-size: var(--text-lg);
-}
-
-.emptyLog span {
+  padding: var(--space-md) var(--space-lg);
   color: var(--c-muted);
   font-size: var(--text-sm);
+  text-align: center;
   text-wrap: pretty;
 }
 

--- a/apps/web/src/pages/calories/dashboard/CaloriesPage.module.css
+++ b/apps/web/src/pages/calories/dashboard/CaloriesPage.module.css
@@ -2,16 +2,19 @@
   display: grid;
   gap: var(--space-lg);
 }
+
 .pageHeader {
   display: flex;
   align-items: end;
   justify-content: space-between;
   gap: var(--space-lg);
 }
+
 .pageHeader h1 {
   font-size: var(--text-xl-dynamic);
   text-wrap: balance;
 }
+
 .pageHeader p,
 .sectionHeading p,
 .cardTitle p,
@@ -19,27 +22,32 @@
   color: var(--c-muted);
   text-wrap: pretty;
 }
+
 .pageHeader time {
   color: var(--c-muted);
   font-size: var(--text-sm);
   white-space: nowrap;
 }
+
 .layout {
   display: grid;
   grid-template-columns: minmax(18rem, 0.78fr) minmax(28rem, 1.22fr);
   align-items: start;
   gap: var(--space-lg);
 }
+
 .overviewStack {
   display: flex;
   flex-direction: column;
   gap: var(--space-lg);
 }
+
 .tools,
 .controlPair {
   display: grid;
   gap: var(--space-lg);
 }
+
 .hero {
   position: relative;
   display: grid;
@@ -48,11 +56,13 @@
   overflow: hidden;
   padding: var(--space-xl);
 }
+
 .heroCopy {
   display: grid;
   align-content: start;
   gap: var(--space-xs);
 }
+
 .sectionLabel,
 label > span {
   color: var(--c-accent-strong);
@@ -61,21 +71,25 @@ label > span {
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
+
 .energyLine {
   display: flex;
   align-items: baseline;
   flex-wrap: wrap;
   gap: var(--space-xs);
 }
+
 .energyLine strong {
   font-size: clamp(2.4rem, 6vw, 4.2rem);
   line-height: 1;
   font-variant-numeric: tabular-nums;
 }
+
 .energyLine span,
 .heroCopy p {
   color: var(--c-muted);
 }
+
 .progress {
   display: grid;
   place-content: center;
@@ -86,16 +100,19 @@ label > span {
   border-radius: var(--radius-pill);
   color: var(--c-accent);
 }
+
 .progress svg {
   width: 1.5rem;
   height: 1.5rem;
 }
+
 .progress span {
   color: var(--c-text-strong);
   font-size: var(--text-sm);
   font-weight: var(--font-weight-semibold);
   font-variant-numeric: tabular-nums;
 }
+
 .progressTrack {
   grid-column: 1 / -1;
   height: 0.4rem;
@@ -103,6 +120,7 @@ label > span {
   border-radius: var(--radius-pill);
   background: var(--c-surface-inset);
 }
+
 .progressTrack span {
   display: block;
   height: 100%;
@@ -110,68 +128,83 @@ label > span {
   background: var(--c-accent);
   transition: width var(--duration-fast) var(--ease-out);
 }
+
 .macroGrid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: var(--space-xs);
 }
+
 .macroStat {
   display: grid;
   gap: 0.25rem;
   padding: var(--space-md);
   border-top: 0.2rem solid currentColor;
 }
+
 .macroStat span {
   color: var(--c-muted);
   font-size: var(--text-xs);
 }
+
 .macroStat strong {
   color: var(--c-text-strong);
   font-size: var(--text-lg);
   font-variant-numeric: tabular-nums;
 }
+
 .protein {
   color: var(--c-macro-protein);
 }
+
 .fat {
   color: var(--c-macro-fat);
 }
+
 .carbs {
   color: var(--c-macro-carb);
 }
+
 .captureCard,
 .compactCard {
   display: grid;
   gap: var(--space-lg);
 }
+
 .logSection {
   display: grid;
   gap: var(--space-sm);
 }
+
 .logHeading {
   display: grid;
   align-items: end;
   gap: var(--space-md);
   padding: 0 var(--space-lg);
 }
+
 .logHeading h2 {
   font-size: var(--text-lg-dynamic);
   text-wrap: balance;
 }
+
 .sectionHeading {
   display: flex;
   justify-content: space-between;
   gap: var(--space-md);
 }
+
 .sectionHeading h2,
 .cardTitle h2 {
   font-size: var(--text-lg-dynamic);
 }
+
 .sectionHeading p,
 .cardTitle p,
 .createFood p {
   font-size: var(--text-sm);
 }
+
 .emptyLog {
   display: grid;
   justify-items: center;
@@ -181,25 +214,30 @@ label > span {
   border-radius: var(--radius-sm);
   text-align: center;
 }
+
 .emptyLog > div:first-child {
   display: grid;
   gap: var(--space-xs);
   max-width: 32rem;
 }
+
 .emptyLog strong {
   font-size: var(--text-lg);
 }
+
 .emptyLog span {
   color: var(--c-muted);
   font-size: var(--text-sm);
   text-wrap: pretty;
 }
+
 .emptyActions {
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
   gap: var(--space-xs);
 }
+
 .logList {
   display: grid;
   gap: var(--space-sm);
@@ -211,27 +249,33 @@ label > span {
     gap: var(--space-xs);
   }
 }
+
 .controlPair {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
+
 .compactCard {
   padding: var(--space-lg);
 }
+
 .cardTitle {
   display: flex;
   align-items: start;
   gap: var(--space-sm);
 }
+
 .cardTitle > svg {
   flex: none;
   color: var(--c-accent);
 }
+
 .inlineForm,
 .quickForm,
 .createFood form {
   display: grid;
   gap: var(--space-md);
 }
+
 .inlineForm label,
 .quickForm label,
 .barcodeForm label,
@@ -241,6 +285,7 @@ label > span {
   display: grid;
   gap: var(--space-xs);
 }
+
 .buttonRow,
 .goalDisplay {
   display: flex;
@@ -248,16 +293,19 @@ label > span {
   justify-content: space-between;
   gap: var(--space-xs);
 }
+
 .goalDisplay strong {
   font-size: var(--text-xl);
   font-variant-numeric: tabular-nums;
 }
+
 .barcodeForm {
   display: grid;
   grid-template-columns: minmax(12rem, 1fr) auto auto;
   align-items: end;
   gap: var(--space-xs);
 }
+
 .foundFood,
 .createFood {
   display: grid;
@@ -267,49 +315,60 @@ label > span {
   border-radius: var(--radius-sm);
   background: var(--c-primary-surface);
 }
+
 .foodIdentity {
   display: flex;
   align-items: center;
   gap: var(--space-sm);
 }
+
 .foodIdentity > svg {
   color: var(--c-accent);
 }
+
 .foodIdentity > div {
   display: grid;
 }
+
 .foodIdentity span {
   color: var(--c-muted);
   font-size: var(--text-sm);
 }
+
 .gramsForm {
   display: grid;
   grid-template-columns: minmax(10rem, 1fr) auto auto;
   align-items: end;
   gap: var(--space-sm);
 }
+
 .energyPreview {
   display: grid;
   min-height: var(--button-min-height);
   align-content: center;
 }
+
 .energyPreview span {
   color: var(--c-muted);
   font-size: var(--text-xs);
 }
+
 .energyPreview strong {
   font-variant-numeric: tabular-nums;
 }
+
 .foodDetails {
   display: grid;
   grid-template-columns: 1.4fr 1fr;
   gap: var(--space-sm);
 }
+
 .nutritionGrid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: var(--space-xs);
 }
+
 label small {
   color: var(--c-muted);
   font-size: inherit;
@@ -320,6 +379,7 @@ label small {
   .layout {
     grid-template-columns: 1fr;
   }
+
   .hero {
     grid-column: 1 / -1;
   }
@@ -328,6 +388,7 @@ label small {
   .hero {
     grid-column: auto;
   }
+
   .nutritionGrid {
     grid-template-columns: repeat(2, 1fr);
   }
@@ -338,20 +399,24 @@ label small {
     flex-direction: column;
     gap: var(--space-xs);
   }
+
   .hero,
   .captureCard {
     padding: var(--space-lg) var(--space-md);
   }
+
   .controlPair,
   .barcodeForm,
   .gramsForm,
   .foodDetails {
     grid-template-columns: 1fr;
   }
+
   .barcodeForm > button,
   .gramsForm > button {
     width: 100%;
   }
+
   .progress {
     width: 5rem;
     height: 5rem;
@@ -370,16 +435,19 @@ label small {
   gap: var(--space-xs);
   width: 100%;
 }
+
 .dayOptions {
   display: grid;
   grid-template-columns: repeat(7, minmax(0, 1fr));
   gap: 0.2rem;
   min-width: 0;
 }
+
 .dayNav {
   flex: none;
   color: var(--c-muted);
 }
+
 .day {
   position: relative;
   min-width: 0;
@@ -394,26 +462,26 @@ label small {
   font: inherit;
   cursor: pointer;
 }
+
 .day.futureDay {
   color: var(--c-placeholder);
 }
+
 .day.todayDay {
   outline: 2px solid var(--c-primary-border-soft);
   outline-offset: -2px;
 }
+
 .day span {
   font-size: var(--text-xs);
 }
+
 .compactDay {
   display: none;
 }
+
 .expandedDay {
   display: block;
-}
-.pageToolbar {
-  display: flex;
-  justify-content: end;
-  margin-bottom: calc(-1 * var(--space-sm));
 }
 
 @media (--phone) {
@@ -426,6 +494,7 @@ label small {
   .compactDay {
     display: block;
   }
+
   .expandedDay {
     display: none;
   }
@@ -435,13 +504,16 @@ label small {
     background: var(--c-surface-raised);
     color: var(--c-text);
   }
+
   .day.futureDay:hover {
     color: var(--c-placeholder);
   }
+
   .dayWithinGoal:hover,
   .dayLogged:hover {
     border-color: var(--c-primary-border);
   }
+
   .dayOverGoal:hover {
     border-color: rgb(248 113 113 / 55%);
   }
@@ -456,6 +528,7 @@ label small {
     var(--c-primary-surface);
   color: var(--c-text);
 }
+
 .dayWithinGoal {
   border-color: color-mix(in srgb, var(--c-macro-carb) 40%, transparent);
   background:
@@ -467,6 +540,7 @@ label small {
     color-mix(in srgb, var(--c-macro-carb) 9%, transparent);
   color: var(--c-text-strong);
 }
+
 .dayOverGoal {
   border-color: var(--c-danger-border);
   background:
@@ -474,19 +548,23 @@ label small {
     var(--c-danger-surface);
   color: var(--c-danger-text);
 }
+
 .day.futureDay.dayLogged,
 .day.futureDay.dayWithinGoal,
 .day.futureDay.dayOverGoal {
   opacity: 0.45;
 }
+
 .day[data-pressed] {
   border-color: transparent;
   background: var(--c-primary-surface-strong);
   color: var(--c-text-strong);
 }
+
 .day[data-pressed].dayWithinGoal {
   border-color: color-mix(in srgb, var(--c-macro-carb) 55%, transparent);
 }
+
 .day[data-pressed].dayOverGoal {
   border-color: rgb(248 113 113 / 60%);
 }

--- a/apps/web/src/pages/calories/dashboard/CaloriesPage.module.css
+++ b/apps/web/src/pages/calories/dashboard/CaloriesPage.module.css
@@ -398,10 +398,10 @@ label small {
 .expandedDay {
   display: block;
 }
-.entryActions {
+.pageToolbar {
   display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-sm);
+  justify-content: end;
+  margin-bottom: calc(-1 * var(--space-sm));
 }
 
 @media (--phone) {

--- a/apps/web/src/pages/calories/dashboard/CaloriesPage.module.css
+++ b/apps/web/src/pages/calories/dashboard/CaloriesPage.module.css
@@ -175,18 +175,30 @@ label > span {
 .emptyLog {
   display: grid;
   justify-items: center;
-  gap: var(--space-xs);
-  padding: var(--space-xl) var(--space-md);
+  gap: var(--space-lg);
+  padding: clamp(var(--space-xl), 8vw, 4rem) var(--space-md);
   border: var(--border-width) dashed var(--c-border-strong);
   border-radius: var(--radius-sm);
   text-align: center;
 }
-.emptyLog svg {
-  color: var(--c-accent);
+.emptyLog > div:first-child {
+  display: grid;
+  gap: var(--space-xs);
+  max-width: 32rem;
+}
+.emptyLog strong {
+  font-size: var(--text-lg);
 }
 .emptyLog span {
   color: var(--c-muted);
   font-size: var(--text-sm);
+  text-wrap: pretty;
+}
+.emptyActions {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
 }
 .logList {
   display: grid;

--- a/apps/web/src/pages/calories/dashboard/CaloriesPage.tsx
+++ b/apps/web/src/pages/calories/dashboard/CaloriesPage.tsx
@@ -37,9 +37,7 @@ export function CaloriesPage({ dashboard, date }: CaloriesPageProps) {
   }
   return (
     <main className={css.page}>
-      <div className={css.pageToolbar} data-appear>
-        <LogFoodMenu date={date} />
-      </div>
+      <LogFoodMenu date={date} />
 
       <div className={css.dayStrip} data-appear>
         <Btn

--- a/apps/web/src/pages/calories/dashboard/CaloriesPage.tsx
+++ b/apps/web/src/pages/calories/dashboard/CaloriesPage.tsx
@@ -1,13 +1,14 @@
 import { Toggle } from '@base-ui/react/toggle';
 import { ToggleGroup } from '@base-ui/react/toggle-group';
 import { useQueryClient } from '@tanstack/react-query';
-import { Link, useNavigate } from '@tanstack/react-router';
+import { useNavigate } from '@tanstack/react-router';
 import clsx from 'clsx';
 import { addDays, format, isAfter, parseISO } from 'date-fns';
 import { ChevronLeftIcon, ChevronRightIcon } from 'lucide-react';
 import type { CalorieDashboard } from '../calories.api';
 import { calorieDashboardQueryOptions } from '../calorieQueries';
 import { CalorieOverview } from './CalorieOverview';
+import { LogFoodMenu } from './LogFoodMenu';
 import { CALORIE_DATE_FORMAT, calorieWeekDates, todayLocalDate } from '../calorieHelpers';
 import { Btn } from '@/components/btn/Btn';
 import css from './CaloriesPage.module.css';
@@ -36,6 +37,10 @@ export function CaloriesPage({ dashboard, date }: CaloriesPageProps) {
   }
   return (
     <main className={css.page}>
+      <div className={css.pageToolbar} data-appear>
+        <LogFoodMenu date={date} />
+      </div>
+
       <div className={css.dayStrip} data-appear>
         <Btn
           aria-label='Previous week'
@@ -113,24 +118,6 @@ export function CaloriesPage({ dashboard, date }: CaloriesPageProps) {
         logs={selectedDay.logs}
         totals={selectedDay.totals}
       />
-
-      <section aria-label='Diary actions' className={css.entryActions} data-appear='3'>
-        <Btn isLink render={<Link search={{ date }} to='/calories/add' />}>
-          Add food
-        </Btn>
-        <Btn isLink render={<Link search={{ date }} to='/calories/scan' />} variant='outlineMain'>
-          Scan barcode
-        </Btn>
-        <Btn isLink render={<Link search={{ date }} to='/calories/quick-add' />} variant='ghost'>
-          Quick add
-        </Btn>
-        <Btn isLink render={<Link search={{ date }} to='/calories/foods/new' />} variant='ghost'>
-          New food
-        </Btn>
-        <Btn isLink render={<Link to='/calories/goals' />} variant='ghost'>
-          Set daily goals
-        </Btn>
-      </section>
     </main>
   );
 }

--- a/apps/web/src/pages/calories/dashboard/DailySummary.module.css
+++ b/apps/web/src/pages/calories/dashboard/DailySummary.module.css
@@ -26,6 +26,13 @@
     radial-gradient(circle at 100% 110%, rgba(167, 227, 161, 0.08), transparent 44%),
     linear-gradient(145deg, rgba(15, 23, 42, 0.7), var(--c-surface-inset));
 }
+.goalAction {
+  position: absolute;
+  top: var(--space-xs);
+  right: var(--space-xs);
+  z-index: 1;
+  color: var(--c-muted);
+}
 
 .energyDial {
   position: relative;

--- a/apps/web/src/pages/calories/dashboard/DailySummary.module.css
+++ b/apps/web/src/pages/calories/dashboard/DailySummary.module.css
@@ -26,6 +26,7 @@
     radial-gradient(circle at 100% 110%, rgba(167, 227, 161, 0.08), transparent 44%),
     linear-gradient(145deg, rgba(15, 23, 42, 0.7), var(--c-surface-inset));
 }
+
 .goalAction {
   position: absolute;
   top: var(--space-xs);
@@ -57,6 +58,7 @@
     stroke-width: 8;
   }
 }
+
 .energyDial:is(button) {
   padding: 0;
   border: 0;
@@ -94,6 +96,7 @@
 .dialGradientEnd {
   stop-color: color-mix(in srgb, currentColor 52%, white);
 }
+
 .dialOverGradientStart {
   stop-color: #fb7185;
 }
@@ -218,6 +221,7 @@
 .carbs {
   color: var(--c-macro-carb);
 }
+
 .protein .macroConsumedOver {
   color: color-mix(in srgb, var(--c-text-strong) 72%, var(--c-macro-protein));
 }

--- a/apps/web/src/pages/calories/dashboard/DailySummary.tsx
+++ b/apps/web/src/pages/calories/dashboard/DailySummary.tsx
@@ -1,3 +1,6 @@
+import { Link } from '@tanstack/react-router';
+import { GoalIcon } from 'lucide-react';
+import { Btn } from '@/components/btn/Btn';
 import { useId, useState } from 'react';
 import type { CalorieGoal, CalorieTotals } from '../calories.api';
 import { formatNutritionNumber } from './nutritionFormat';
@@ -20,6 +23,16 @@ export function DailySummary({ goal, totals }: DailySummaryProps) {
     <section aria-label='Daily nutrition summary' className={css.summary} data-appear='1'>
       <div className={css.body}>
         <div className={css.energyPanel}>
+          <Btn
+            className={css.goalAction}
+            icon={<GoalIcon aria-hidden='true' />}
+            isLink
+            render={<Link to='/calories/goals' />}
+            size='sm'
+            variant='ghost'
+          >
+            {goal ? 'Edit goals' : 'Set goals'}
+          </Btn>
           <EnergyDial
             goal={goal?.kcal}
             progress={energyProgress}

--- a/apps/web/src/pages/calories/dashboard/DailySummary.tsx
+++ b/apps/web/src/pages/calories/dashboard/DailySummary.tsx
@@ -29,7 +29,7 @@ export function DailySummary({ goal, totals }: DailySummaryProps) {
             isLink
             render={<Link to='/calories/goals' />}
             size='sm'
-            variant='ghost'
+            variant='text'
           >
             {goal ? 'Edit goals' : 'Set goals'}
           </Btn>

--- a/apps/web/src/pages/calories/dashboard/LogFoodMenu.module.css
+++ b/apps/web/src/pages/calories/dashboard/LogFoodMenu.module.css
@@ -1,0 +1,163 @@
+.trigger {
+  margin-left: auto;
+}
+.chevron {
+  width: 1rem;
+  transition: transform var(--duration-fast) ease-in-out;
+}
+.trigger[data-popup-open] .chevron {
+  transform: rotate(180deg);
+}
+.positioner {
+  z-index: 30;
+  outline: none;
+}
+.popup {
+  display: grid;
+  width: min(23rem, calc(100vw - 2rem));
+  padding: var(--space-xs);
+  border: var(--border-width) solid var(--c-border-strong);
+  border-radius: var(--radius-md);
+  background: var(--c-surface-raised);
+  box-shadow: var(--shadow-popup);
+  color: var(--c-text);
+  transform-origin: var(--transform-origin);
+}
+.popup[data-open] {
+  animation: menu-in 160ms ease-out;
+}
+.popup[data-closed] {
+  animation: menu-out 100ms ease-in-out;
+}
+.mobileHeading {
+  display: none;
+}
+.item {
+  display: grid;
+  grid-template-columns: 2.5rem minmax(0, 1fr);
+  align-items: center;
+  gap: var(--space-sm);
+  min-height: 3.5rem;
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: var(--radius-sm);
+  color: inherit;
+  text-decoration: none;
+  outline: none;
+  cursor: pointer;
+}
+.item[data-highlighted] {
+  background: var(--c-primary-surface);
+}
+.itemIcon {
+  display: grid;
+  place-items: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border: var(--border-width) solid var(--c-primary-border-soft);
+  border-radius: var(--radius-sm);
+  background: var(--c-primary-surface);
+  color: var(--c-accent);
+}
+.itemIcon svg {
+  width: 1.2rem;
+  height: 1.2rem;
+}
+.itemCopy {
+  display: grid;
+  gap: 0.1rem;
+  min-width: 0;
+}
+.itemCopy strong {
+  font-size: var(--text-sm);
+}
+.itemCopy > span {
+  overflow: hidden;
+  color: var(--c-muted);
+  font-size: var(--text-xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.separator {
+  height: var(--border-width);
+  margin: var(--space-xs) var(--space-sm);
+  background: var(--c-border);
+}
+@keyframes menu-in {
+  from {
+    opacity: 0;
+    transform: scale(0.97) translateY(-0.25rem);
+  }
+}
+@keyframes menu-out {
+  to {
+    opacity: 0;
+    transform: scale(0.98);
+  }
+}
+@media (--phone) {
+  .trigger {
+    position: fixed;
+    right: var(--space-md);
+    bottom: calc(4.75rem + env(safe-area-inset-bottom, 0px));
+    z-index: 20;
+    box-shadow: var(--shadow-card-primary);
+  }
+  .positioner {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: end;
+    width: 100%;
+    height: 100%;
+    padding: var(--space-sm);
+    background: color-mix(in srgb, var(--c-surface-inset) 75%, transparent);
+  }
+  .popup {
+    width: 100%;
+    max-height: calc(100dvh - 2rem);
+    padding: var(--space-sm);
+    border-radius: var(--radius-md);
+  }
+  .popup[data-open] {
+    animation-name: sheet-in;
+  }
+  .popup[data-closed] {
+    animation-name: sheet-out;
+  }
+  .mobileHeading {
+    display: grid;
+    gap: 0.15rem;
+    padding: var(--space-sm) var(--space-sm) var(--space-md);
+  }
+  .mobileHeading strong {
+    font-size: var(--text-lg);
+  }
+  .mobileHeading span {
+    color: var(--c-muted);
+    font-size: var(--text-sm);
+  }
+  .item {
+    min-height: 4rem;
+  }
+  @keyframes sheet-in {
+    from {
+      opacity: 0;
+      transform: translateY(1rem);
+    }
+  }
+  @keyframes sheet-out {
+    to {
+      opacity: 0;
+      transform: translateY(0.5rem);
+    }
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .popup[data-open],
+  .popup[data-closed] {
+    animation: none;
+  }
+  .chevron {
+    transition: none;
+  }
+}

--- a/apps/web/src/pages/calories/dashboard/LogFoodMenu.tsx
+++ b/apps/web/src/pages/calories/dashboard/LogFoodMenu.tsx
@@ -1,8 +1,14 @@
-import { Menu } from '@base-ui/react/menu';
 import { Link } from '@tanstack/react-router';
-import { BarcodeIcon, ChevronDownIcon, PlusIcon, ScanLineIcon, SparklesIcon } from 'lucide-react';
-import { Btn } from '@/components/btn/Btn';
-import css from './LogFoodMenu.module.css';
+import { BarcodeIcon, PlusIcon, ScanLineIcon, SparklesIcon } from 'lucide-react';
+import { FloatingButton } from '@/components/floating-button/FloatingButton';
+import {
+  MenuBtn,
+  MenuBtnChevron,
+  MenuBtnDivider,
+  MenuBtnItem,
+  MenuBtnPopup,
+  MenuBtnRoot,
+} from '@/components/menu-btn/MenuBtn';
 
 type Props = { date: string };
 
@@ -29,56 +35,36 @@ const loggingActions = [
 
 export function LogFoodMenu({ date }: Props) {
   return (
-    <Menu.Root>
-      <Menu.Trigger
-        render={
-          <Btn className={css.trigger} icon={<PlusIcon aria-hidden='true' />} radius='pill' />
-        }
-      >
+    <MenuBtnRoot>
+      <FloatingButton icon={<PlusIcon aria-hidden='true' />} render={<MenuBtn />}>
         Log food
-        <ChevronDownIcon aria-hidden='true' className={css.chevron} />
-      </Menu.Trigger>
-      <Menu.Portal>
-        <Menu.Positioner align='end' className={css.positioner} sideOffset={8}>
-          <Menu.Popup aria-label='Log food' className={css.popup}>
-            <div className={css.mobileHeading}>
-              <strong>Log food</strong>
-              <span>Choose how you want to add this entry.</span>
-            </div>
-            {loggingActions.map((action) => {
-              const ActionIcon = action.icon;
-              return (
-                <Menu.Item
-                  className={css.item}
-                  key={action.to}
-                  render={<Link search={{ date }} to={action.to} />}
-                >
-                  <span className={css.itemIcon}>
-                    <ActionIcon aria-hidden='true' />
-                  </span>
-                  <span className={css.itemCopy}>
-                    <strong>{action.label}</strong>
-                    <span>{action.description}</span>
-                  </span>
-                </Menu.Item>
-              );
-            })}
-            <Menu.Separator className={css.separator} />
-            <Menu.Item
-              className={css.item}
-              render={<Link search={{ date }} to='/calories/foods/new' />}
-            >
-              <span className={css.itemIcon}>
-                <BarcodeIcon aria-hidden='true' />
-              </span>
-              <span className={css.itemCopy}>
-                <strong>Create a new food</strong>
-                <span>Save nutrition details for reuse</span>
-              </span>
-            </Menu.Item>
-          </Menu.Popup>
-        </Menu.Positioner>
-      </Menu.Portal>
-    </Menu.Root>
+        <MenuBtnChevron />
+      </FloatingButton>
+      <MenuBtnPopup
+        aria-label='Log food'
+        description='Choose how you want to add this entry.'
+        heading='Log food'
+      >
+        {loggingActions.map((action) => {
+          const ActionIcon = action.icon;
+          return (
+            <MenuBtnItem
+              description={action.description}
+              icon={<ActionIcon aria-hidden='true' />}
+              key={action.to}
+              label={action.label}
+              render={<Link search={{ date }} to={action.to} />}
+            />
+          );
+        })}
+        <MenuBtnDivider />
+        <MenuBtnItem
+          description='Save nutrition details for reuse'
+          icon={<BarcodeIcon aria-hidden='true' />}
+          label='Create a new food'
+          render={<Link search={{ date }} to='/calories/foods/new' />}
+        />
+      </MenuBtnPopup>
+    </MenuBtnRoot>
   );
 }

--- a/apps/web/src/pages/calories/dashboard/LogFoodMenu.tsx
+++ b/apps/web/src/pages/calories/dashboard/LogFoodMenu.tsx
@@ -1,0 +1,84 @@
+import { Menu } from '@base-ui/react/menu';
+import { Link } from '@tanstack/react-router';
+import { BarcodeIcon, ChevronDownIcon, PlusIcon, ScanLineIcon, SparklesIcon } from 'lucide-react';
+import { Btn } from '@/components/btn/Btn';
+import css from './LogFoodMenu.module.css';
+
+type Props = { date: string };
+
+const loggingActions = [
+  {
+    description: 'Search your foods and choose a serving',
+    icon: PlusIcon,
+    label: 'Add food',
+    to: '/calories/add' as const,
+  },
+  {
+    description: 'Use the camera or enter a barcode',
+    icon: ScanLineIcon,
+    label: 'Scan barcode',
+    to: '/calories/scan' as const,
+  },
+  {
+    description: 'Enter calories and macros directly',
+    icon: SparklesIcon,
+    label: 'Quick add',
+    to: '/calories/quick-add' as const,
+  },
+];
+
+export function LogFoodMenu({ date }: Props) {
+  return (
+    <Menu.Root>
+      <Menu.Trigger
+        render={
+          <Btn className={css.trigger} icon={<PlusIcon aria-hidden='true' />} radius='pill' />
+        }
+      >
+        Log food
+        <ChevronDownIcon aria-hidden='true' className={css.chevron} />
+      </Menu.Trigger>
+      <Menu.Portal>
+        <Menu.Positioner align='end' className={css.positioner} sideOffset={8}>
+          <Menu.Popup aria-label='Log food' className={css.popup}>
+            <div className={css.mobileHeading}>
+              <strong>Log food</strong>
+              <span>Choose how you want to add this entry.</span>
+            </div>
+            {loggingActions.map((action) => {
+              const ActionIcon = action.icon;
+              return (
+                <Menu.Item
+                  className={css.item}
+                  key={action.to}
+                  render={<Link search={{ date }} to={action.to} />}
+                >
+                  <span className={css.itemIcon}>
+                    <ActionIcon aria-hidden='true' />
+                  </span>
+                  <span className={css.itemCopy}>
+                    <strong>{action.label}</strong>
+                    <span>{action.description}</span>
+                  </span>
+                </Menu.Item>
+              );
+            })}
+            <Menu.Separator className={css.separator} />
+            <Menu.Item
+              className={css.item}
+              render={<Link search={{ date }} to='/calories/foods/new' />}
+            >
+              <span className={css.itemIcon}>
+                <BarcodeIcon aria-hidden='true' />
+              </span>
+              <span className={css.itemCopy}>
+                <strong>Create a new food</strong>
+                <span>Save nutrition details for reuse</span>
+              </span>
+            </Menu.Item>
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
+  );
+}

--- a/apps/web/src/pages/components-demo/ComponentsDemoPage.tsx
+++ b/apps/web/src/pages/components-demo/ComponentsDemoPage.tsx
@@ -9,6 +9,14 @@ import { DefaultCatchBoundary } from '@/components/default-catch-boundary/Defaul
 import { ErrorCard } from '@/components/error-card/ErrorCard';
 import { FloatingButton } from '@/components/floating-button/FloatingButton';
 import { Label } from '@/components/label/Label';
+import {
+  MenuBtn,
+  MenuBtnChevron,
+  MenuBtnDivider,
+  MenuBtnItem,
+  MenuBtnPopup,
+  MenuBtnRoot,
+} from '@/components/menu-btn/MenuBtn';
 import { Navbar } from '@/components/navbar/Navbar';
 import { NotFound } from '@/components/not-found/NotFound';
 import { PillBtn } from '@/components/pill-btn/PillBtn';
@@ -103,6 +111,33 @@ export function ComponentsDemoPage() {
           )}
           rows={BTN_VARIANTS}
         />
+      </section>
+
+      <section>
+        <h2>MenuBtn</h2>
+        <MenuBtnRoot>
+          <Btn icon={<PlusIcon aria-hidden='true' />} render={<MenuBtn />}>
+            Open menu
+            <MenuBtnChevron />
+          </Btn>
+          <MenuBtnPopup
+            aria-label='Demo menu'
+            description='Reusable popup parts composed with Btn.'
+            heading='Demo menu'
+          >
+            <MenuBtnItem
+              description='An item with supporting copy'
+              icon={<PlusIcon aria-hidden='true' />}
+              label='Primary action'
+            />
+            <MenuBtnDivider />
+            <MenuBtnItem
+              description='Items can be separated into groups'
+              icon={<SearchIcon aria-hidden='true' />}
+              label='Secondary action'
+            />
+          </MenuBtnPopup>
+        </MenuBtnRoot>
       </section>
 
       <section>

--- a/apps/web/src/pages/home/HomeDashboard.module.css
+++ b/apps/web/src/pages/home/HomeDashboard.module.css
@@ -309,6 +309,7 @@
 .diaryLines i:nth-child(2) {
   width: 78%;
 }
+
 .diaryLines i:nth-child(3) {
   width: 48%;
 }
@@ -363,12 +364,15 @@
 .orbitPeople i:nth-child(1) {
   left: 0;
 }
+
 .orbitPeople i:nth-child(2) {
   left: 26%;
 }
+
 .orbitPeople i:nth-child(3) {
   right: 26%;
 }
+
 .orbitPeople i:nth-child(4) {
   right: 0;
   border-color: var(--c-macro-fat);
@@ -497,12 +501,15 @@
 .repRail i:nth-child(2) {
   height: 55%;
 }
+
 .repRail i:nth-child(3) {
   height: 85%;
 }
+
 .repRail i:nth-child(4) {
   height: 62%;
 }
+
 .repRail i:nth-child(5) {
   height: 100%;
 }

--- a/apps/web/src/styles/theme.css
+++ b/apps/web/src/styles/theme.css
@@ -126,9 +126,7 @@
   --shadow-card-danger: 0 24px 70px rgba(127, 29, 29, 0.28);
   --shadow-popup: 0 24px 60px rgba(2, 6, 23, 0.4);
   --shadow-image: drop-shadow(0 30px 60px rgba(15, 23, 42, 0.5));
-  --blur-surface: blur(16px);
-  --blur-navigation: blur(22px);
-  --blur-image-overlay: blur(8px);
+  --blur-surface: blur(8px);
 
   --duration-fast: 0.2s;
   --ease-out: cubic-bezier(0.22, 1, 0.36, 1);

--- a/apps/web/src/styles/theme.css
+++ b/apps/web/src/styles/theme.css
@@ -127,6 +127,8 @@
   --shadow-popup: 0 24px 60px rgba(2, 6, 23, 0.4);
   --shadow-image: drop-shadow(0 30px 60px rgba(15, 23, 42, 0.5));
   --blur-surface: blur(16px);
+  --blur-navigation: blur(22px);
+  --blur-image-overlay: blur(8px);
 
   --duration-fast: 0.2s;
   --ease-out: cubic-bezier(0.22, 1, 0.36, 1);

--- a/stylelint.config.mjs
+++ b/stylelint.config.mjs
@@ -17,6 +17,7 @@ export default {
     'no-duplicate-selectors': true,
     'no-invalid-double-slash-comments': true,
     'property-no-unknown': true,
+    'rule-empty-line-before': ['always', { except: ['first-nested'], ignore: ['after-comment'] }],
     'selector-pseudo-class-no-unknown': true,
     'selector-pseudo-element-no-unknown': true,
     'unit-no-unknown': true,


### PR DESCRIPTION
## What changed
- combines the responsive logging menu, contextual goal action, and guided empty diary state into one PR
- extracts reusable `MenuBtn` popup, item, divider, chevron, and root parts for composition with `Btn`
- lets `FloatingButton` render composed controls and uses it as the sole food-logging action on the calories dashboard
- uses React 19 ref props instead of `forwardRef` in the reusable trigger
- adds a real Base UI menu backdrop so phone taps dismiss the sheet
- pins the phone sheet to the dynamic viewport and safe area so it is not offset or clipped
- standardizes every backdrop filter on one `--blur-surface: blur(8px)` theme token
- enforces blank lines between CSS rules with autofixable Stylelint configuration
- adds the shared menu primitive to the components demo

## Verification
- `pnpm check:fix` — 14 test files passed; 42 tests passed
- `pnpm --filter @veles/web build`

## Stack
- combines former PRs #109 and #110 into this PR
- rebased onto `stack/calories/08/camera-scanner`