### PR TITLE
Add appear animations to main pages

### DIFF
--- a/apps/web/src/pages/account/AccountPage.tsx
+++ b/apps/web/src/pages/account/AccountPage.tsx
@@ -69,7 +69,7 @@ export function AccountPage({ user }: AccountPageProps) {
 
   return (
     <main className={css.page}>
-      <Card as='section' className={css.profileCard} variant='primary'>
+      <Card as='section' className={css.profileCard} data-appear variant='primary'>
         <Avatar.Root className={css.profileAvatar}>
           {user.image ? <Avatar.Image alt='' className={css.avatarImage} src={user.image} /> : null}
           <Avatar.Fallback className={css.profileFallback}>{accountInitials}</Avatar.Fallback>
@@ -90,7 +90,7 @@ export function AccountPage({ user }: AccountPageProps) {
         </Btn>
       </Card>
 
-      <Card as='section' className={css.friendsCard}>
+      <Card as='section' className={css.friendsCard} data-appear='1'>
         <header className={css.sectionHeader}>
           <div>
             <h2>Friends</h2>

--- a/apps/web/src/pages/diary/DiaryListPage.tsx
+++ b/apps/web/src/pages/diary/DiaryListPage.tsx
@@ -44,12 +44,12 @@ export function DiaryListPage({ entries }: DiaryListPageProps) {
       ) : null}
 
       {entries.length === 0 ? (
-        <Card as='section' className={css.emptyState}>
+        <Card as='section' className={css.emptyState} data-appear>
           <h1>No diary entries yet</h1>
         </Card>
       ) : (
         <>
-          <label className={css.searchField}>
+          <label className={css.searchField} data-appear>
             <span className={css.searchLabel}>Search entries</span>
             <TextInput
               aria-label='Search diary entries'
@@ -63,12 +63,12 @@ export function DiaryListPage({ entries }: DiaryListPageProps) {
           </label>
 
           {visibleEntries.length === 0 ? (
-            <Card as='section' className={css.emptyState}>
+            <Card as='section' className={css.emptyState} data-appear='1'>
               <h1>No matching entries</h1>
               <p>Try a different title or phrase from an entry.</p>
             </Card>
           ) : (
-            <section aria-label='Diary entries' className={css.list}>
+            <section aria-label='Diary entries' className={css.list} data-appear='1'>
               {visibleEntries.map((entry) => (
                 <Link
                   className={css.entryLink}

--- a/apps/web/src/pages/recipes/RecipesPage.tsx
+++ b/apps/web/src/pages/recipes/RecipesPage.tsx
@@ -28,7 +28,7 @@ export function RecipesPage({ recipes }: RecipesPageProps) {
   return (
     <main className={css.page}>
       <title>Recipes</title>
-      <section className={css.controls}>
+      <section className={css.controls} data-appear>
         <div className={css.toolbar}>
           <label className={css.searchField}>
             <TextInput
@@ -45,7 +45,7 @@ export function RecipesPage({ recipes }: RecipesPageProps) {
         </div>
       </section>
 
-      <section className={css.grid}>
+      <section className={css.grid} data-appear='1'>
         {visibleRecipes.map((recipe) => (
           <Link
             className={css.cardLink}

--- a/apps/web/src/pages/todos/TodosPage.tsx
+++ b/apps/web/src/pages/todos/TodosPage.tsx
@@ -26,7 +26,7 @@ const todoLists = [
 export function TodosPage() {
   return (
     <main className={css.page}>
-      <header className={css.header}>
+      <header className={css.header} data-appear>
         <div>
           <h1>Todos</h1>
           <p>Simple checklists for your shopping cart and life goals.</p>
@@ -42,9 +42,11 @@ export function TodosPage() {
         </Btn>
       </header>
 
-      <p className={css.mockNote}>Mock only — editing and sharing are coming next.</p>
+      <p className={css.mockNote} data-appear='1'>
+        Mock only — editing and sharing are coming next.
+      </p>
 
-      <section aria-label='Example todo lists' className={css.listGrid}>
+      <section aria-label='Example todo lists' className={css.listGrid} data-appear='2'>
         {todoLists.map((list) => (
           <Card as='article' className={css.listCard} key={list.title}>
             <h2>{list.title}</h2>

--- a/apps/web/src/pages/weight/WeightPage.tsx
+++ b/apps/web/src/pages/weight/WeightPage.tsx
@@ -55,10 +55,12 @@ export function WeightPage({ entries, initialChartRange }: WeightPageProps) {
   return (
     <main className={css.page}>
       {entries.length > 0 && (
-        <WeightTrendChart entries={entries} initialRange={initialChartRange} />
+        <div data-appear>
+          <WeightTrendChart entries={entries} initialRange={initialChartRange} />
+        </div>
       )}
 
-      <section aria-label="Today's weight" className={css.captureContainer}>
+      <section aria-label="Today's weight" className={css.captureContainer} data-appear='1'>
         <WeightForm
           isSaving={saveMutation.isPending}
           onChange={setWeightKg}
@@ -89,7 +91,7 @@ export function WeightPage({ entries, initialChartRange }: WeightPageProps) {
 
       {entries.length > 0 ? (
         <>
-          <div className={css.summaryRail}>
+          <div className={css.summaryRail} data-appear='2'>
             <Card as='section' aria-label='Weight summary' className={css.summaryGrid}>
               <SummaryStat label='Current' value={`${latestEntry!.weightKg.toFixed(1)} kg`} />
               <SummaryStat label='2 weeks' value={formatChange(twoWeekChange)} />
@@ -97,10 +99,12 @@ export function WeightPage({ entries, initialChartRange }: WeightPageProps) {
             </Card>
           </div>
 
-          <RecentWeightEntries entries={entries} />
+          <div data-appear='3'>
+            <RecentWeightEntries entries={entries} />
+          </div>
         </>
       ) : (
-        <Card as='section' className={css.emptyState}>
+        <Card as='section' className={css.emptyState} data-appear='2'>
           <h1>Start tracking your weight</h1>
           <p>Add today&apos;s weight or import your history to begin building your trend.</p>
         </Card>


### PR DESCRIPTION
## Summary
- animate primary content regions on Diary, Todos, Recipes, Weight, and Account
- stagger related regions with the existing global data-appear timing
- preserve reduced-motion behavior through the existing global styles

## Verification
- pnpm check:fix