### PR TITLE
Add guided calorie goal calculator

### DIFF
--- a/apps/web/src/pages/calories/goals/CalorieGoalCalculator.tsx
+++ b/apps/web/src/pages/calories/goals/CalorieGoalCalculator.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import { Btn } from '@/components/btn/Btn';
+import { Label } from '@/components/label/Label';
+import { NumberInput } from '@/components/number-input/NumberInput';
+import { SelectInput } from '@/components/select-input/SelectInput';
+import {
+  estimateMaintenanceKcal,
+  macrosFromPercentages,
+  type ActivityLevel,
+  type FormulaSex,
+  type MacroPercentages,
+  type NutritionGoalValues,
+} from './calorieGoalCalculator';
+import css from './CalorieGoalsPage.module.css';
+
+const SEX_OPTIONS = [
+  { label: 'Female formula', value: 'female' },
+  { label: 'Male formula', value: 'male' },
+] as const;
+
+const ACTIVITY_OPTIONS = [
+  { label: 'Little exercise · mostly seated', value: 'sedentary' },
+  { label: 'Light · exercise 1–3 days/week', value: 'light' },
+  { label: 'Moderate · exercise 3–5 days/week', value: 'moderate' },
+  { label: 'Very active · hard exercise 6–7 days/week', value: 'very-active' },
+] as const;
+
+type CalorieGoalCalculatorProps = {
+  initialWeightKg: number | null;
+  percentages: MacroPercentages;
+  onApply: (values: NutritionGoalValues) => void;
+};
+
+/** Collects the inputs needed for a transparent maintenance-calorie estimate. */
+export function CalorieGoalCalculator({
+  initialWeightKg,
+  onApply,
+  percentages,
+}: CalorieGoalCalculatorProps) {
+  const [age, setAge] = useState<number | null>(null);
+  const [sex, setSex] = useState<FormulaSex | null>(null);
+  const [weightKg, setWeightKg] = useState<number | null>(initialWeightKg);
+  const [heightCm, setHeightCm] = useState<number | null>(null);
+  const [activity, setActivity] = useState<ActivityLevel | null>(null);
+  const hasRequiredInputs =
+    age !== null &&
+    age >= 18 &&
+    age <= 120 &&
+    sex !== null &&
+    weightKg !== null &&
+    weightKg >= 30 &&
+    weightKg <= 400 &&
+    heightCm !== null &&
+    heightCm >= 120 &&
+    heightCm <= 250 &&
+    activity !== null;
+
+  function applyEstimate() {
+    if (!hasRequiredInputs) return;
+
+    const kcal = estimateMaintenanceKcal({ age, sex, weightKg, heightCm, activity });
+    onApply(macrosFromPercentages(kcal, percentages));
+  }
+
+  return (
+    <section className={css.method}>
+      <div className={css.methodHeading}>
+        <h2>
+          <span aria-hidden='true'>1.</span> Estimate maintenance calories
+        </h2>
+      </div>
+
+      <div className={css.calculatorGrid}>
+        <Label text='Age'>
+          <NumberInput max={120} min={18} onValueChange={setAge} placeholder='Years' />
+        </Label>
+        <Label text='Formula sex'>
+          <SelectInput
+            items={SEX_OPTIONS}
+            onValueChange={setSex}
+            placeholder='Choose formula'
+            value={sex}
+          />
+        </Label>
+        <Label text='Weight'>
+          <NumberInput max={400} min={30} onValueChange={setWeightKg} placeholder='kg' />
+        </Label>
+        <Label text='Height'>
+          <NumberInput max={250} min={120} onValueChange={setHeightCm} placeholder='cm' />
+        </Label>
+        <Label className={css.activityField} text='Weekly activity'>
+          <SelectInput
+            items={ACTIVITY_OPTIONS}
+            onValueChange={setActivity}
+            placeholder='Choose activity level'
+            value={activity}
+          />
+        </Label>
+      </div>
+
+      <p className={css.formulaNote}>
+        The equation has only female and male variants, so this choice affects the formula only.
+        Actual needs can vary; compare the estimate with your weight trend for a few weeks.
+      </p>
+      <Btn
+        disabled={!hasRequiredInputs}
+        onClick={applyEstimate}
+        type='button'
+        variant='outlineMain'
+      >
+        Use maintenance estimate
+      </Btn>
+    </section>
+  );
+}

--- a/apps/web/src/pages/calories/goals/CalorieGoalsPage.module.css
+++ b/apps/web/src/pages/calories/goals/CalorieGoalsPage.module.css
@@ -1,0 +1,122 @@
+@import '../../../styles/breakpoints.css';
+
+.method,
+.currentGoals {
+  display: grid;
+  gap: var(--space-md);
+  padding: var(--space-lg);
+  border: var(--border-width) solid var(--c-border);
+  border-radius: var(--radius-sm);
+  background: var(--c-surface);
+}
+
+.methodHeading {
+  h2 {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-xs);
+    color: var(--c-text-strong);
+    font-size: var(--text-lg-dynamic);
+    text-wrap: balance;
+  }
+
+  span {
+    color: var(--c-muted-strong);
+    font-family: inherit;
+    font-size: inherit;
+    font-variant-numeric: tabular-nums;
+  }
+}
+
+.calculatorGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-sm);
+}
+
+.activityField {
+  grid-column: 1 / -1;
+}
+
+.formulaNote {
+  color: var(--c-muted-strong);
+  font-size: var(--text-xs);
+  text-wrap: pretty;
+}
+
+.presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xs);
+}
+
+.percentGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-sm);
+}
+
+.validTotal,
+.invalidTotal {
+  justify-self: end;
+  font-size: var(--text-sm);
+  font-variant-numeric: tabular-nums;
+}
+
+.validTotal {
+  color: var(--c-muted);
+}
+
+.invalidTotal {
+  color: var(--c-danger-text);
+}
+
+.currentGoals {
+  gap: var(--space-lg);
+  border-color: var(--c-primary-border-soft);
+  background:
+    linear-gradient(135deg, var(--c-primary-surface) 0%, transparent 48%), var(--c-surface-strong);
+  box-shadow: var(--shadow-card-primary);
+
+  > button {
+    justify-self: end;
+  }
+}
+
+.currentGoalsHeading {
+  h2 {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-xs);
+    color: var(--c-text-strong);
+    font-size: var(--text-xl-dynamic);
+    text-wrap: balance;
+  }
+
+  span {
+    color: var(--c-muted-strong);
+    font-family: inherit;
+    font-size: inherit;
+    font-variant-numeric: tabular-nums;
+  }
+}
+
+@media (--phone) {
+  .method,
+  .currentGoals {
+    padding: var(--space-md);
+  }
+
+  .calculatorGrid,
+  .percentGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .activityField {
+    grid-column: auto;
+  }
+
+  .currentGoals > button {
+    width: 100%;
+  }
+}

--- a/apps/web/src/pages/calories/goals/CalorieGoalsPage.tsx
+++ b/apps/web/src/pages/calories/goals/CalorieGoalsPage.tsx
@@ -1,4 +1,5 @@
 import type { UseNavigateResult } from '@tanstack/react-router';
+import { useState } from 'react';
 import type { CalorieGoal } from '../calories.api';
 import { useSetDailyCalorieGoalMutation } from '../calories.query';
 import { todayLocalDate } from '../calorieHelpers';
@@ -6,9 +7,35 @@ import { Btn } from '@/components/btn/Btn';
 import { KcalMacrosForm } from '@/components/kcal-macros-form/KcalMacrosForm';
 import { TypedForm } from '@/components/typed-form/TypedForm';
 import { TypedFormData } from '@/components/typed-form/TypedFormData';
-import css from '../CalorieFlows.module.css';
+import { CalorieGoalCalculator } from './CalorieGoalCalculator';
+import {
+  DEFAULT_MACRO_PERCENTAGES,
+  macrosFromPercentages,
+  percentagesFromMacros,
+  type MacroPercentages,
+  type NutritionGoalValues,
+} from './calorieGoalCalculator';
+import { MacroPercentageEditor } from './MacroPercentageEditor';
+import css from './CalorieGoalsPage.module.css';
+import flowCss from '../CalorieFlows.module.css';
 
-export function CalorieGoalsPage({ goal }: { goal: CalorieGoal | null }) {
+export function CalorieGoalsPage({
+  goal,
+  latestWeightKg,
+}: {
+  goal: CalorieGoal | null;
+  latestWeightKg: number | null;
+}) {
+  const initialValues: NutritionGoalValues = {
+    kcal: goal?.kcal ?? null,
+    protein: goal?.protein ?? null,
+    fat: goal?.fat ?? null,
+    carbs: goal?.carbs ?? null,
+  };
+  const [values, setValues] = useState(initialValues);
+  const [percentages, setPercentages] = useState(() =>
+    percentagesFromMacros(initialValues, DEFAULT_MACRO_PERCENTAGES),
+  );
   const goalMutation = useSetDailyCalorieGoalMutation();
   async function submit(formData: TypedFormData, navigate: UseNavigateResult<string>) {
     const date = todayLocalDate();
@@ -21,31 +48,50 @@ export function CalorieGoalsPage({ goal }: { goal: CalorieGoal | null }) {
     });
     await navigate({ to: '/calories', search: { date } });
   }
+
+  function applyPercentages(nextPercentages: MacroPercentages) {
+    setPercentages(nextPercentages);
+    if (values.kcal !== null) setValues(macrosFromPercentages(values.kcal, nextPercentages));
+  }
+
+  function updateGoalValue(field: keyof NutritionGoalValues, value: number | null) {
+    if (field === 'kcal') {
+      setValues(
+        value === null ? { ...values, kcal: null } : macrosFromPercentages(value, percentages),
+      );
+      return;
+    }
+
+    const nextValues = { ...values, [field]: value };
+    setValues(nextValues);
+    setPercentages(percentagesFromMacros(nextValues, percentages));
+  }
   return (
-    <main className={css.page}>
-      <header className={css.header}>
-        <div>
-          <h1>Current goals</h1>
-          <p>Changes start today. Earlier goals stay frozen.</p>
-        </div>
+    <main className={flowCss.page}>
+      <header className={flowCss.header}>
+        <h1>Current goals</h1>
       </header>
-      <section className={css.panel}>
-        <TypedForm className={css.form} onSubmit={submit}>
-          <KcalMacrosForm
-            defaultValues={{
-              kcal: goal?.kcal,
-              protein: goal?.protein,
-              fat: goal?.fat,
-              carbs: goal?.carbs,
-            }}
-            kcalInput={{ min: 1 }}
-          />
+      <TypedForm className={flowCss.form} onSubmit={submit}>
+        <CalorieGoalCalculator
+          initialWeightKg={latestWeightKg}
+          onApply={setValues}
+          percentages={percentages}
+        />
+        <MacroPercentageEditor onChange={applyPercentages} percentages={percentages} />
+
+        <section className={css.currentGoals}>
+          <div className={css.currentGoalsHeading}>
+            <h2>
+              <span aria-hidden='true'>3.</span> Review daily targets
+            </h2>
+          </div>
+          <KcalMacrosForm kcalInput={{ min: 1 }} onValueChange={updateGoalValue} values={values} />
 
           <Btn loading={goalMutation.isPending} type='submit'>
             Save current goals
           </Btn>
-        </TypedForm>
-      </section>
+        </section>
+      </TypedForm>
     </main>
   );
 }

--- a/apps/web/src/pages/calories/goals/MacroPercentageEditor.tsx
+++ b/apps/web/src/pages/calories/goals/MacroPercentageEditor.tsx
@@ -1,0 +1,89 @@
+import { Btn } from '@/components/btn/Btn';
+import { Label } from '@/components/label/Label';
+import { NumberInput } from '@/components/number-input/NumberInput';
+import { macroPercentageTotal, type MacroPercentages } from './calorieGoalCalculator';
+import css from './CalorieGoalsPage.module.css';
+
+const PRESETS: ReadonlyArray<{ label: string; values: MacroPercentages }> = [
+  { label: 'Balanced', values: { protein: 25, fat: 30, carbs: 45 } },
+  { label: 'Higher protein', values: { protein: 30, fat: 30, carbs: 40 } },
+  { label: 'Lower carb', values: { protein: 30, fat: 40, carbs: 30 } },
+];
+
+type MacroPercentageEditorProps = {
+  percentages: MacroPercentages;
+  onChange: (percentages: MacroPercentages) => void;
+};
+
+/** Edits the calorie allocation and exposes neutral presets as understandable starting points. */
+export function MacroPercentageEditor({ onChange, percentages }: MacroPercentageEditorProps) {
+  const total = macroPercentageTotal(percentages);
+  const hasValidTotal = Math.abs(total - 100) < 0.05;
+
+  function update(field: keyof MacroPercentages, value: number | null) {
+    onChange({ ...percentages, [field]: value ?? 0 });
+  }
+
+  return (
+    <section className={css.method}>
+      <div className={css.methodHeading}>
+        <h2>
+          <span aria-hidden='true'>2.</span> Split calories into macros
+        </h2>
+      </div>
+
+      <div aria-label='Macro split presets' className={css.presets}>
+        {PRESETS.map((preset) => {
+          const selected =
+            preset.values.protein === percentages.protein &&
+            preset.values.fat === percentages.fat &&
+            preset.values.carbs === percentages.carbs;
+
+          return (
+            <Btn
+              aria-pressed={selected}
+              key={preset.label}
+              onClick={() => onChange(preset.values)}
+              size='sm'
+              type='button'
+              variant={selected ? 'main' : 'outlineMain'}
+            >
+              {preset.label}
+            </Btn>
+          );
+        })}
+      </div>
+
+      <div className={css.percentGrid}>
+        <Label text='Protein (%)'>
+          <NumberInput
+            max={100}
+            min={0}
+            onValueChange={(value) => update('protein', value)}
+            value={percentages.protein}
+          />
+        </Label>
+        <Label text='Fat (%)'>
+          <NumberInput
+            max={100}
+            min={0}
+            onValueChange={(value) => update('fat', value)}
+            value={percentages.fat}
+          />
+        </Label>
+        <Label text='Carbs (%)'>
+          <NumberInput
+            max={100}
+            min={0}
+            onValueChange={(value) => update('carbs', value)}
+            value={percentages.carbs}
+          />
+        </Label>
+      </div>
+
+      <p aria-live='polite' className={hasValidTotal ? css.validTotal : css.invalidTotal}>
+        Total: {total.toFixed(1).replace('.0', '')}%{hasValidTotal ? '' : ' — adjust to 100%'}
+      </p>
+    </section>
+  );
+}

--- a/apps/web/src/pages/calories/goals/calorieGoalCalculator.test.ts
+++ b/apps/web/src/pages/calories/goals/calorieGoalCalculator.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import {
+  estimateMaintenanceKcal,
+  macrosFromPercentages,
+  percentagesFromMacros,
+} from './calorieGoalCalculator';
+
+describe('calorie goal calculator', () => {
+  it('estimates maintenance calories with Mifflin–St Jeor and activity', () => {
+    expect(
+      estimateMaintenanceKcal({
+        age: 30,
+        sex: 'male',
+        weightKg: 80,
+        heightCm: 180,
+        activity: 'moderate',
+      }),
+    ).toBe(2759);
+  });
+
+  it('converts calorie percentages to gram targets in kcal, protein, fat, carbs order', () => {
+    expect(macrosFromPercentages(2000, { protein: 25, fat: 30, carbs: 45 })).toEqual({
+      kcal: 2000,
+      protein: 125,
+      fat: 66.7,
+      carbs: 225,
+    });
+  });
+
+  it('reflects direct gram edits back into calorie percentages', () => {
+    expect(percentagesFromMacros({ kcal: 2000, protein: 150, fat: 60, carbs: 215 })).toEqual({
+      protein: 30,
+      fat: 27,
+      carbs: 43,
+    });
+  });
+});

--- a/apps/web/src/pages/calories/goals/calorieGoalCalculator.ts
+++ b/apps/web/src/pages/calories/goals/calorieGoalCalculator.ts
@@ -1,0 +1,82 @@
+export type FormulaSex = 'female' | 'male';
+export type ActivityLevel = 'sedentary' | 'light' | 'moderate' | 'very-active';
+export type MacroPercentages = {
+  protein: number;
+  fat: number;
+  carbs: number;
+};
+export type NutritionGoalValues = {
+  kcal: number | null;
+  protein: number | null;
+  fat: number | null;
+  carbs: number | null;
+};
+
+export const DEFAULT_MACRO_PERCENTAGES: MacroPercentages = {
+  protein: 25,
+  fat: 30,
+  carbs: 45,
+};
+
+const ACTIVITY_MULTIPLIERS: Record<ActivityLevel, number> = {
+  sedentary: 1.2,
+  light: 1.375,
+  moderate: 1.55,
+  'very-active': 1.725,
+};
+
+/** Estimates maintenance energy with Mifflin–St Jeor and a standard activity multiplier. */
+export function estimateMaintenanceKcal(input: {
+  age: number;
+  sex: FormulaSex;
+  weightKg: number;
+  heightCm: number;
+  activity: ActivityLevel;
+}) {
+  const sexConstant = input.sex === 'male' ? 5 : -161;
+  const restingKcal = 10 * input.weightKg + 6.25 * input.heightCm - 5 * input.age + sexConstant;
+
+  return Math.round(restingKcal * ACTIVITY_MULTIPLIERS[input.activity]);
+}
+
+/** Converts calorie percentages into gram targets using 4/9/4 kcal per gram. */
+export function macrosFromPercentages(
+  kcal: number,
+  percentages: MacroPercentages,
+): NutritionGoalValues {
+  return {
+    kcal,
+    protein: roundToOneDecimal((kcal * percentages.protein) / 100 / 4),
+    fat: roundToOneDecimal((kcal * percentages.fat) / 100 / 9),
+    carbs: roundToOneDecimal((kcal * percentages.carbs) / 100 / 4),
+  };
+}
+
+/** Derives each macro's calorie share so direct gram edits stay reflected in the percentage editor. */
+export function percentagesFromMacros(
+  values: NutritionGoalValues,
+  fallback: MacroPercentages = DEFAULT_MACRO_PERCENTAGES,
+): MacroPercentages {
+  if (!values.kcal || values.kcal <= 0) return fallback;
+
+  return {
+    protein:
+      values.protein === null
+        ? fallback.protein
+        : roundToOneDecimal((values.protein * 4 * 100) / values.kcal),
+    fat:
+      values.fat === null ? fallback.fat : roundToOneDecimal((values.fat * 9 * 100) / values.kcal),
+    carbs:
+      values.carbs === null
+        ? fallback.carbs
+        : roundToOneDecimal((values.carbs * 4 * 100) / values.kcal),
+  };
+}
+
+export function macroPercentageTotal(percentages: MacroPercentages) {
+  return percentages.protein + percentages.fat + percentages.carbs;
+}
+
+function roundToOneDecimal(value: number) {
+  return Math.round(value * 10) / 10;
+}

--- a/apps/web/src/pages/calories/goals/goals.api.ts
+++ b/apps/web/src/pages/calories/goals/goals.api.ts
@@ -1,7 +1,8 @@
 import { type } from 'arktype';
 import { arkTypeValidator } from '@tanstack/arktype-adapter';
 import { createServerFn } from '@tanstack/react-start';
-import { calorieGoals } from '@veles/db/schema';
+import { desc, eq } from 'drizzle-orm';
+import { calorieGoals, weightEntries } from '@veles/db/schema';
 import { requireSession } from '@/lib/auth/getSession';
 import { dateOnlyType } from '@/lib/dateOnly';
 import { db } from '@/lib/db';
@@ -17,6 +18,20 @@ const setDailyCalorieGoalInputType = type({
   'carbs?': optionalPositiveAmountType,
   date: dateOnlyType,
 });
+
+export const getLatestWeightKg = createServerFn({ method: 'GET' })
+  .middleware([logMiddleware('getLatestWeightKg')])
+  .handler(async () => {
+    const session = await requireSession();
+    const [latestWeight] = await db
+      .select({ weightGrams: weightEntries.weightGrams })
+      .from(weightEntries)
+      .where(eq(weightEntries.userId, session.user.id))
+      .orderBy(desc(weightEntries.date))
+      .limit(1);
+
+    return latestWeight ? latestWeight.weightGrams / 1_000 : null;
+  });
 
 export const setDailyCalorieGoal = createServerFn({ method: 'POST' })
   .middleware([logMiddleware('setDailyCalorieGoal')])

--- a/apps/web/src/routes/_authenticated/calories_/goals.tsx
+++ b/apps/web/src/routes/_authenticated/calories_/goals.tsx
@@ -3,10 +3,17 @@ import { createFileRoute } from '@tanstack/react-router';
 import { CalorieGoalsPage } from '@/pages/calories/goals/CalorieGoalsPage';
 import { calorieDashboardQueryOptions } from '@/pages/calories/calories.query';
 import { todayLocalDate } from '@/pages/calories/calorieHelpers';
+import { getLatestWeightKg } from '@/pages/calories/goals/goals.api';
 
 export const Route = createFileRoute('/_authenticated/calories_/goals')({
-  loader: ({ context }) =>
-    context.queryClient.ensureQueryData(calorieDashboardQueryOptions(todayLocalDate())),
+  loader: async ({ context }) => {
+    const [, latestWeightKg] = await Promise.all([
+      context.queryClient.ensureQueryData(calorieDashboardQueryOptions(todayLocalDate())),
+      getLatestWeightKg(),
+    ]);
+
+    return { latestWeightKg };
+  },
   component: Component,
   staticData: {
     navbar: {
@@ -18,8 +25,9 @@ export const Route = createFileRoute('/_authenticated/calories_/goals')({
 
 function Component() {
   const { data: dashboard } = useSuspenseQuery(calorieDashboardQueryOptions(todayLocalDate()));
+  const { latestWeightKg } = Route.useLoaderData();
   const today = todayLocalDate();
   const goal = dashboard.days.find((day) => day.date === today)?.goal ?? null;
 
-  return <CalorieGoalsPage goal={goal} />;
+  return <CalorieGoalsPage goal={goal} latestWeightKg={latestWeightKg} />;
 }


### PR DESCRIPTION
## Summary
- add a guided maintenance-calorie estimator using age, formula sex, weight, height, and activity
- prefill the estimator with the user's latest recorded weight when available
- add macro percentage presets and synchronize them with the existing kcal/macros form
- present the workflow as three compact numbered steps

## Verification
- pnpm check:fix
- 19 test files passed, 56 tests passed