### PR TITLE
Fix camera access for food photo picker

### DIFF
--- a/apps/web/src/pages/calories/PhotoPicker.tsx
+++ b/apps/web/src/pages/calories/PhotoPicker.tsx
@@ -87,6 +87,7 @@ export function PhotoPicker({
       <input
         ref={inputRef}
         accept='image/*'
+        capture='environment'
         aria-label='Upload photo'
         className={css.fileInput}
         onChange={(event) => {


### PR DESCRIPTION
## Summary\n- add the environment camera capture hint to the food photo input\n- preserve image file selection behavior\n\n## Verification\n- pnpm check:fix