### PR TITLE
Fix mobile food amount submission

### DIFF
--- a/apps/web/src/components/ui/number-input/NumberInput.tsx
+++ b/apps/web/src/components/ui/number-input/NumberInput.tsx
@@ -1,5 +1,6 @@
 import { NumberField, type NumberFieldRootProps } from '@base-ui/react/number-field';
 import clsx from 'clsx';
+import type { ComponentPropsWithoutRef } from 'react';
 import { MinusIcon, PlusIcon } from 'lucide-react';
 import { useRef } from 'react';
 import css from './NumberInput.module.css';
@@ -8,12 +9,14 @@ type NumberInputProps = Omit<NumberFieldRootProps, 'className' | 'step'> & {
   className?: string;
   inputClassName?: string;
   placeholder?: string;
+  enterKeyHint?: ComponentPropsWithoutRef<'input'>['enterKeyHint'];
   stepperStep?: number;
 };
 
 export function NumberInput({
   className,
   inputClassName,
+  enterKeyHint,
   placeholder,
   stepperStep,
   ...props
@@ -50,6 +53,7 @@ export function NumberInput({
         <NumberField.Input
           ref={inputRef}
           className={clsx(css.input, inputClassName)}
+          enterKeyHint={enterKeyHint}
           onChange={(event) => {
             event.currentTarget.value = normalizeDecimalSeparator(event.currentTarget.value);
           }}

--- a/apps/web/src/pages/calories/add/SelectedFoodForm.module.css
+++ b/apps/web/src/pages/calories/add/SelectedFoodForm.module.css
@@ -75,6 +75,13 @@
   width: 100%;
 }
 
+.amountEntry {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: var(--space-sm);
+}
+
 .packageShortcuts {
   display: grid;
   gap: var(--space-xs);
@@ -190,7 +197,7 @@
 
 .actions {
   display: flex;
-  justify-content: flex-end;
+  justify-content: flex-start;
   gap: var(--space-sm);
 }
 

--- a/apps/web/src/pages/calories/add/SelectedFoodForm.tsx
+++ b/apps/web/src/pages/calories/add/SelectedFoodForm.tsx
@@ -8,6 +8,7 @@ import { GoalPreview } from './GoalPreview';
 import { Btn } from '@/components/ui/btn/Btn';
 import { DateInput } from '@/components/ui/date-input/DateInput';
 import { Label } from '@/components/ui/label/Label';
+import { TypedForm } from '@/components/ui/typed-form/TypedForm';
 import { NumberInput } from '@/components/ui/number-input/NumberInput';
 import { NutritionInline } from '../NutritionInline';
 import css from './SelectedFoodForm.module.css';
@@ -72,7 +73,7 @@ export function SelectedFoodForm({ cancelLabel, food, initialDate, onCancel }: P
         </div>
       </section>
 
-      <section className={css.panel}>
+      <TypedForm className={css.panel} onSubmit={save}>
         {recordFoodMutation.error ? (
           <p className={css.error} role='alert'>
             {recordFoodMutation.error.toString()}
@@ -84,9 +85,24 @@ export function SelectedFoodForm({ cancelLabel, food, initialDate, onCancel }: P
             <DateInput onValueChange={setDate} value={date} />
           </Label>
           <div className={css.amountField}>
-            <Label text='Amount eaten (g)'>
-              <NumberInput min={1} onValueChange={setGrams} value={grams} />
-            </Label>
+            <div className={css.amountEntry}>
+              <Label text='Amount eaten (g)'>
+                <NumberInput
+                  enterKeyHint='done'
+                  min={1}
+                  required
+                  onValueChange={setGrams}
+                  value={grams}
+                />
+              </Label>
+              <Btn
+                disabled={selectedGrams < 1}
+                loading={recordFoodMutation.isPending}
+                type='submit'
+              >
+                Save
+              </Btn>
+            </div>
             {packageSizeGrams !== null && packageSizeGrams > 0 ? (
               <div
                 aria-label='Package amount shortcuts'
@@ -133,19 +149,16 @@ export function SelectedFoodForm({ cancelLabel, food, initialDate, onCancel }: P
           pending={dashboardQuery.isPending}
         />
         <div className={css.actions}>
-          <Btn disabled={recordFoodMutation.isPending} onClick={onCancel} variant='ghost'>
+          <Btn
+            disabled={recordFoodMutation.isPending}
+            onClick={onCancel}
+            type='button'
+            variant='ghost'
+          >
             {cancelLabel}
           </Btn>
-          <Btn
-            loading={recordFoodMutation.isPending}
-            onClick={() => {
-              void save();
-            }}
-          >
-            Save
-          </Btn>
         </div>
-      </section>
+      </TypedForm>
     </main>
   );
 }


### PR DESCRIPTION
## Changes
- place Save beside the amount input so it remains visible above the mobile keyboard
- submit the food form from the keyboard action and show a Done enter-key hint
- keep the lower-priority Go back action below the calorie preview

## Verification
- pnpm --filter @veles/web typecheck
- pnpm check:fix