### PR TITLE
chore: move auth and pnpm housekeeping

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 11.5.0
+          version: 12.3.4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -6,7 +6,7 @@ ARG VITE_CF_CDN_URL=https://cdn.example.com
 ENV VITE_APP_NAME=$VITE_APP_NAME
 ENV VITE_CF_CDN_URL=$VITE_CF_CDN_URL
 
-RUN npm install -g pnpm@11.5.0
+RUN npm install -g pnpm@12.3.4
 
 WORKDIR /app
 

--- a/apps/web/src/pages/login/AuthErrorPage.module.css
+++ b/apps/web/src/pages/login/AuthErrorPage.module.css
@@ -1,0 +1,111 @@
+.page {
+  display: grid;
+  align-items: center;
+  min-height: calc(100vh - 11rem);
+}
+
+.card {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: var(--space-md);
+  width: min(100%, 46rem);
+  margin: 0 auto;
+  padding: clamp(var(--space-lg), 5vw, 2.5rem);
+}
+
+.signal {
+  display: grid;
+  width: 3rem;
+  height: 3rem;
+  place-items: center;
+  border: 1px solid var(--c-danger-border);
+  border-radius: 50%;
+  background: var(--c-danger-surface);
+  color: var(--c-danger-text);
+}
+
+.content {
+  display: grid;
+  align-content: start;
+  gap: var(--space-md);
+  min-width: 0;
+}
+
+.content h1 {
+  max-width: 19ch;
+  color: var(--c-text-strong);
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+  letter-spacing: -0.045em;
+  line-height: 1.05;
+  text-wrap: balance;
+}
+
+.message {
+  max-width: 42rem;
+  color: var(--c-muted);
+  font-size: var(--text-md-dynamic);
+  text-wrap: pretty;
+}
+
+.details {
+  display: grid;
+  gap: var(--space-xs);
+  width: fit-content;
+  max-width: 100%;
+  color: var(--c-muted-strong);
+  font-size: var(--text-xs);
+}
+
+.details summary {
+  cursor: pointer;
+  width: fit-content;
+  min-height: 2.5rem;
+  padding-block: 0.7rem;
+  color: var(--c-accent-soft);
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+}
+
+.details summary:focus-visible {
+  outline: 2px solid var(--c-primary-focus);
+  outline-offset: 3px;
+}
+
+.details code {
+  display: block;
+  overflow-wrap: anywhere;
+  padding: var(--space-sm);
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius-xs);
+  background: var(--c-surface-inset);
+  color: var(--c-muted-soft);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  padding-top: var(--space-xs);
+}
+
+@media (--phone) {
+  .page {
+    align-items: start;
+    min-height: calc(100vh - 8rem);
+    padding-top: var(--space-xl);
+  }
+
+  .card {
+    grid-template-columns: 1fr;
+  }
+
+  .actions {
+    display: grid;
+  }
+
+  .actions > a {
+    width: 100%;
+  }
+}

--- a/apps/web/src/pages/login/AuthErrorPage.module.css
+++ b/apps/web/src/pages/login/AuthErrorPage.module.css
@@ -4,24 +4,9 @@
   min-height: calc(100vh - 11rem);
 }
 
-.card {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: var(--space-md);
+.panel {
   width: min(100%, 46rem);
   margin: 0 auto;
-  padding: clamp(var(--space-lg), 5vw, 2.5rem);
-}
-
-.signal {
-  display: grid;
-  width: 3rem;
-  height: 3rem;
-  place-items: center;
-  border: 1px solid var(--c-danger-border);
-  border-radius: 50%;
-  background: var(--c-danger-surface);
-  color: var(--c-danger-text);
 }
 
 .content {
@@ -47,42 +32,6 @@
   text-wrap: pretty;
 }
 
-.details {
-  display: grid;
-  gap: var(--space-xs);
-  width: fit-content;
-  max-width: 100%;
-  color: var(--c-muted-strong);
-  font-size: var(--text-xs);
-}
-
-.details summary {
-  cursor: pointer;
-  width: fit-content;
-  min-height: 2.5rem;
-  padding-block: 0.7rem;
-  color: var(--c-accent-soft);
-  text-decoration: underline;
-  text-underline-offset: 0.2em;
-}
-
-.details summary:focus-visible {
-  outline: 2px solid var(--c-primary-focus);
-  outline-offset: 3px;
-}
-
-.details code {
-  display: block;
-  overflow-wrap: anywhere;
-  padding: var(--space-sm);
-  border: 1px solid var(--c-border);
-  border-radius: var(--radius-xs);
-  background: var(--c-surface-inset);
-  color: var(--c-muted-soft);
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-}
-
 .actions {
   display: flex;
   flex-wrap: wrap;
@@ -95,10 +44,6 @@
     align-items: start;
     min-height: calc(100vh - 8rem);
     padding-top: var(--space-xl);
-  }
-
-  .card {
-    grid-template-columns: 1fr;
   }
 
   .actions {

--- a/apps/web/src/pages/login/AuthErrorPage.tsx
+++ b/apps/web/src/pages/login/AuthErrorPage.tsx
@@ -14,10 +14,6 @@ const AUTH_ERROR_COPY: { default: AuthErrorCopy; [code: string]: AuthErrorCopy }
     title: 'We could not finish signing you in',
     msg: 'Something interrupted sign-in. Return to the sign-in page and try again.',
   },
-  this_account_needs_a_connection_invitation_to_use_veles: {
-    title: 'An invitation is needed',
-    msg: 'This Google account is not connected to Veles yet. Ask a Veles member to invite this email address, then come back and try again.',
-  },
 };
 
 export function AuthErrorPage({ code }: { code?: string }) {

--- a/apps/web/src/pages/login/AuthErrorPage.tsx
+++ b/apps/web/src/pages/login/AuthErrorPage.tsx
@@ -1,42 +1,42 @@
 import { Link } from '@tanstack/react-router';
-import { ArrowLeftIcon, CircleAlertIcon, HomeIcon } from 'lucide-react';
+import { ArrowLeftIcon, HomeIcon } from 'lucide-react';
 import { Btn } from '@/components/ui/btn/Btn';
 import { Card } from '@/components/ui/card/Card';
 import css from './AuthErrorPage.module.css';
 
-const invitationErrorCode = 'this_account_needs_a_connection_invitation_to_use_veles';
+type AuthErrorCopy = {
+  msg: string;
+  title: string;
+};
 
-export function AuthErrorPage({ code, description }: { code?: string; description?: string }) {
-  const normalizedCode = code?.trim().toLowerCase() ?? '';
-  const needsInvitation = normalizedCode === invitationErrorCode;
-  const displayCode = code?.replaceAll('_', ' ') || 'Unknown sign-in error';
-  const title = needsInvitation ? 'An invitation is needed' : 'We could not finish signing you in';
-  const message = needsInvitation
-    ? 'This Google account is not connected to Veles yet. Ask a Veles member to invite this email address, then come back and try again.'
-    : description?.replaceAll('_', ' ') ||
-      'Something interrupted sign-in. Return to the sign-in page and try again.';
+const AUTH_ERROR_COPY: { default: AuthErrorCopy; [code: string]: AuthErrorCopy } = {
+  default: {
+    msg: 'Something interrupted sign-in. Return to the sign-in page and try again.',
+    title: 'We could not finish signing you in',
+  },
+  this_account_needs_a_connection_invitation_to_use_veles: {
+    msg: 'This Google account is not connected to Veles yet. Ask a Veles member to invite this email address, then come back and try again.',
+    title: 'An invitation is needed',
+  },
+};
+
+export function AuthErrorPage({ code }: { code?: string }) {
+  const normalizedCode = code?.trim().toLowerCase() ?? 'default';
+  const copy = AUTH_ERROR_COPY[normalizedCode] ?? AUTH_ERROR_COPY.default;
 
   return (
     <main className={css.page}>
       <Card
         aria-labelledby='auth-error-title'
         as='section'
-        className={css.card}
+        className={css.panel}
         data-appear
         role='alert'
         variant='danger'
       >
-        <div className={css.signal}>
-          <CircleAlertIcon aria-hidden='true' size={22} strokeWidth={1.8} />
-        </div>
         <div className={css.content}>
-          <h1 id='auth-error-title'>{title}</h1>
-          <p className={css.message}>{message}</p>
-
-          <details className={css.details}>
-            <summary>View technical details</summary>
-            <code>{displayCode}</code>
-          </details>
+          <h1 id='auth-error-title'>{copy.title}</h1>
+          <p className={css.message}>{copy.msg}</p>
 
           <div className={css.actions}>
             <Btn

--- a/apps/web/src/pages/login/AuthErrorPage.tsx
+++ b/apps/web/src/pages/login/AuthErrorPage.tsx
@@ -5,18 +5,18 @@ import { Card } from '@/components/ui/card/Card';
 import css from './AuthErrorPage.module.css';
 
 type AuthErrorCopy = {
-  msg: string;
   title: string;
+  msg: string;
 };
 
 const AUTH_ERROR_COPY: { default: AuthErrorCopy; [code: string]: AuthErrorCopy } = {
   default: {
-    msg: 'Something interrupted sign-in. Return to the sign-in page and try again.',
     title: 'We could not finish signing you in',
+    msg: 'Something interrupted sign-in. Return to the sign-in page and try again.',
   },
   this_account_needs_a_connection_invitation_to_use_veles: {
-    msg: 'This Google account is not connected to Veles yet. Ask a Veles member to invite this email address, then come back and try again.',
     title: 'An invitation is needed',
+    msg: 'This Google account is not connected to Veles yet. Ask a Veles member to invite this email address, then come back and try again.',
   },
 };
 

--- a/apps/web/src/pages/login/AuthErrorPage.tsx
+++ b/apps/web/src/pages/login/AuthErrorPage.tsx
@@ -1,0 +1,63 @@
+import { Link } from '@tanstack/react-router';
+import { ArrowLeftIcon, CircleAlertIcon, HomeIcon } from 'lucide-react';
+import { Btn } from '@/components/ui/btn/Btn';
+import { Card } from '@/components/ui/card/Card';
+import css from './AuthErrorPage.module.css';
+
+const invitationErrorCode = 'this_account_needs_a_connection_invitation_to_use_veles';
+
+export function AuthErrorPage({ code, description }: { code?: string; description?: string }) {
+  const normalizedCode = code?.trim().toLowerCase() ?? '';
+  const needsInvitation = normalizedCode === invitationErrorCode;
+  const displayCode = code?.replaceAll('_', ' ') || 'Unknown sign-in error';
+  const title = needsInvitation ? 'An invitation is needed' : 'We could not finish signing you in';
+  const message = needsInvitation
+    ? 'This Google account is not connected to Veles yet. Ask a Veles member to invite this email address, then come back and try again.'
+    : description?.replaceAll('_', ' ') ||
+      'Something interrupted sign-in. Return to the sign-in page and try again.';
+
+  return (
+    <main className={css.page}>
+      <Card
+        aria-labelledby='auth-error-title'
+        as='section'
+        className={css.card}
+        data-appear
+        role='alert'
+        variant='danger'
+      >
+        <div className={css.signal}>
+          <CircleAlertIcon aria-hidden='true' size={22} strokeWidth={1.8} />
+        </div>
+        <div className={css.content}>
+          <h1 id='auth-error-title'>{title}</h1>
+          <p className={css.message}>{message}</p>
+
+          <details className={css.details}>
+            <summary>View technical details</summary>
+            <code>{displayCode}</code>
+          </details>
+
+          <div className={css.actions}>
+            <Btn
+              icon={<ArrowLeftIcon aria-hidden='true' size={17} />}
+              isLink
+              render={<Link to='/login' />}
+              variant='main'
+            >
+              Back to sign in
+            </Btn>
+            <Btn
+              icon={<HomeIcon aria-hidden='true' size={17} />}
+              isLink
+              render={<Link to='/' />}
+              variant='outlineMain'
+            >
+              Go home
+            </Btn>
+          </div>
+        </div>
+      </Card>
+    </main>
+  );
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as AuthenticatedCaloriesRouteImport } from './routes/_authenticat
 import { Route as AuthenticatedTodosRouteImport } from './routes/_authenticated/todos'
 import { Route as AuthenticatedWeightRouteImport } from './routes/_authenticated/weight'
 import { Route as ApiHealthRouteImport } from './routes/api/health'
+import { Route as AuthErrorRouteImport } from './routes/auth.error'
 import { Route as DemoComponentsRouteImport } from './routes/demo.components'
 import { Route as AuthenticatedCaloriesAddRouteImport } from './routes/_authenticated/calories_/add'
 import { Route as AuthenticatedCaloriesGoalsRouteImport } from './routes/_authenticated/calories_/goals'
@@ -73,6 +74,11 @@ const AuthenticatedWeightRoute = AuthenticatedWeightRouteImport.update({
 const ApiHealthRoute = ApiHealthRouteImport.update({
   id: '/api/health',
   path: '/api/health',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AuthErrorRoute = AuthErrorRouteImport.update({
+  id: '/auth/error',
+  path: '/auth/error',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DemoComponentsRoute = DemoComponentsRouteImport.update({
@@ -184,6 +190,7 @@ export interface FileRoutesByFullPath {
   '/todos': typeof AuthenticatedTodosRoute
   '/weight': typeof AuthenticatedWeightRoute
   '/api/health': typeof ApiHealthRoute
+  '/auth/error': typeof AuthErrorRoute
   '/demo/components': typeof DemoComponentsRoute
   '/calories/add': typeof AuthenticatedCaloriesAddRoute
   '/calories/goals': typeof AuthenticatedCaloriesGoalsRoute
@@ -211,6 +218,7 @@ export interface FileRoutesByTo {
   '/todos': typeof AuthenticatedTodosRoute
   '/weight': typeof AuthenticatedWeightRoute
   '/api/health': typeof ApiHealthRoute
+  '/auth/error': typeof AuthErrorRoute
   '/demo/components': typeof DemoComponentsRoute
   '/calories/add': typeof AuthenticatedCaloriesAddRoute
   '/calories/goals': typeof AuthenticatedCaloriesGoalsRoute
@@ -240,6 +248,7 @@ export interface FileRoutesById {
   '/_authenticated/todos': typeof AuthenticatedTodosRoute
   '/_authenticated/weight': typeof AuthenticatedWeightRoute
   '/api/health': typeof ApiHealthRoute
+  '/auth/error': typeof AuthErrorRoute
   '/demo/components': typeof DemoComponentsRoute
   '/_authenticated/calories_/add': typeof AuthenticatedCaloriesAddRoute
   '/_authenticated/calories_/goals': typeof AuthenticatedCaloriesGoalsRoute
@@ -269,6 +278,7 @@ export interface FileRouteTypes {
     | '/todos'
     | '/weight'
     | '/api/health'
+    | '/auth/error'
     | '/demo/components'
     | '/calories/add'
     | '/calories/goals'
@@ -296,6 +306,7 @@ export interface FileRouteTypes {
     | '/todos'
     | '/weight'
     | '/api/health'
+    | '/auth/error'
     | '/demo/components'
     | '/calories/add'
     | '/calories/goals'
@@ -324,6 +335,7 @@ export interface FileRouteTypes {
     | '/_authenticated/todos'
     | '/_authenticated/weight'
     | '/api/health'
+    | '/auth/error'
     | '/demo/components'
     | '/_authenticated/calories_/add'
     | '/_authenticated/calories_/goals'
@@ -349,6 +361,7 @@ export interface RootRouteChildren {
   AuthenticatedRoute: typeof AuthenticatedRouteWithChildren
   LoginRoute: typeof LoginRoute
   ApiHealthRoute: typeof ApiHealthRoute
+  AuthErrorRoute: typeof AuthErrorRoute
   DemoComponentsRoute: typeof DemoComponentsRoute
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
   ApiDemoPingRoute: typeof ApiDemoPingRoute
@@ -411,6 +424,13 @@ declare module '@tanstack/react-router' {
       path: '/api/health'
       fullPath: '/api/health'
       preLoaderRoute: typeof ApiHealthRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/auth/error': {
+      id: '/auth/error'
+      path: '/auth/error'
+      fullPath: '/auth/error'
+      preLoaderRoute: typeof AuthErrorRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/demo/components': {
@@ -593,6 +613,7 @@ const rootRouteChildren: RootRouteChildren = {
   AuthenticatedRoute: AuthenticatedRouteWithChildren,
   LoginRoute: LoginRoute,
   ApiHealthRoute: ApiHealthRoute,
+  AuthErrorRoute: AuthErrorRoute,
   DemoComponentsRoute: DemoComponentsRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
   ApiDemoPingRoute: ApiDemoPingRoute,

--- a/apps/web/src/routes/auth.error.tsx
+++ b/apps/web/src/routes/auth.error.tsx
@@ -9,7 +9,7 @@ export const Route = createFileRoute('/auth/error')({
 });
 
 function AuthErrorRoute() {
-  const { error, error_description: description } = Route.useSearch();
+  const { error } = Route.useSearch();
 
-  return <AuthErrorPage code={error} description={description} />;
+  return <AuthErrorPage code={error} />;
 }

--- a/apps/web/src/routes/auth.error.tsx
+++ b/apps/web/src/routes/auth.error.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { type } from 'arktype';
+import { AuthErrorPage } from '@/pages/login/AuthErrorPage';
+
+export const Route = createFileRoute('/auth/error')({
+  validateSearch: type({ 'error?': 'string', 'error_description?': 'string' }),
+  component: AuthErrorRoute,
+  head: () => ({ meta: [{ title: 'Sign-in error' }] }),
+});
+
+function AuthErrorRoute() {
+  const { error, error_description: description } = Route.useSearch();
+
+  return <AuthErrorPage code={error} description={description} />;
+}

--- a/apps/web/src/server/auth.server.ts
+++ b/apps/web/src/server/auth.server.ts
@@ -10,6 +10,9 @@ const env = getServerEnv();
 export const auth = betterAuth({
   baseURL: env.appUrl,
   secret: env.betterAuthSecret,
+  onAPIError: {
+    errorURL: new URL('/auth/error', env.appUrl).toString(),
+  },
   database: drizzleAdapter(db, {
     provider: 'pg',
     schema: {

--- a/apps/web/src/server/auth.server.ts
+++ b/apps/web/src/server/auth.server.ts
@@ -51,6 +51,7 @@ export const auth = betterAuth({
           google: {
             clientId: env.googleClientId,
             clientSecret: env.googleClientSecret,
+            prompt: 'select_account',
           },
         }
       : {},

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -2,7 +2,7 @@ FROM node:26.2.0-alpine
 
 ENV NODE_ENV=production
 
-RUN npm install -g pnpm@11.5.0
+RUN npm install -g pnpm@12.3.4
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -36,5 +36,5 @@
   "engines": {
     "node": ">=26.2.0"
   },
-  "packageManager": "pnpm@11.5.0"
+  "packageManager": "pnpm@12.3.4"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.3.4
+        version: 12.3.4
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.3.4':
+    resolution: {integrity: sha512-PAyUol8T1+/+ViOiXAt51ECA+QnfXCqz6foL4bW+LsoX0NcVd5XVEM2mRQu+LV4oc7uRz9zf9U0P+XFfuQeDAw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.3.4':
+    resolution: {integrity: sha512-fxP9JCk0Cdye+ePuj+GJJLMUMTqHGWRdb1dtv4How876uQ2ehxvenpgiYAir/ceO9PsYUZkFTtyZdx+rRu5QOA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.3.4':
+    resolution: {integrity: sha512-FBOt0/7ye6O6q4AllVV5QMviB6qE6fqkeczV/+MDWQsmo+QJrlfsh6X7CpH/tClVpBZEyIbjpUoT8bNhCYBxEg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.3.4':
+    resolution: {integrity: sha512-t71AVA7LRqiKTyZ5xMYaZc2n5DfdpMbfokZuiIOXHBOM03ECnF0t4iYwaBDqJgVjlKYUOwaF/bRQajGNA4cJ4w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.3.4':
+    resolution: {integrity: sha512-RPmk7Jb/aYaFvL2iyDN/AtMY+hUEsue732WmXpcuQ9tBpMnGyA5py7Z3+e+qmQaJ0zY/4ni9jJiyPBQHujmv6w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.3.4':
+    resolution: {integrity: sha512-2ZqOlSPkfwX1h5cR+FPiWf8+F+2hZT/3TvhUK5sigHqwaQCIiq8R7CGxhndKs63JtcLi2a1Qpo+wX/EoyfjyJQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.3.4':
+    resolution: {integrity: sha512-ANyrHqyqco6SXBysUTRF74itDyyraea7IbFsKFdNXTjcFnfycTDx37EwuhdpPYFNSIh2JhUG4fByclsRfiHX7w==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.3.4':
+    resolution: {integrity: sha512-WH/KqBPY/hq2Tb7SgQltEZytimcjgKRaCRL/aM9CI0c67iKc5TVmHUhIiL3Ux9FB4bWn36i6XewUcScQI+zG8w==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.3.4:
+    resolution: {integrity: sha512-lhqkH7B32joEpEHZ+OFevAyW2o73ELLrZ7+e58sGEOq9SPH9hfUc/+c4RnhfoPh8VqOocqHYk/hEZ0G1zORUVw==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.3.4':
+    optional: true
+
+  pnpm@12.3.4:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.3.4
+      '@pnpm/exe.darwin-x64': 12.3.4
+      '@pnpm/exe.linux-arm64': 12.3.4
+      '@pnpm/exe.linux-arm64-musl': 12.3.4
+      '@pnpm/exe.linux-x64': 12.3.4
+      '@pnpm/exe.linux-x64-musl': 12.3.4
+      '@pnpm/exe.win32-arm64': 12.3.4
+      '@pnpm/exe.win32-x64': 12.3.4
+
+---
 lockfileVersion: '9.0'
 
 settings:


### PR DESCRIPTION
## Changes
- upgrade repository, CI, and Docker images to pnpm 12.3.4
- always show the Google account chooser during sign-in
- route Better Auth failures to a production sign-in error page
- keep invitation-specific copy out until invitation support is deployed

## Verification
- pnpm dlx pnpm@12.3.4 check:fix
- pnpm dlx pnpm@12.3.4 build