### PR TITLE
Keep weight save actions above mobile keyboard

### DIFF
--- a/apps/web/src/pages/weight/AddWeightPage.tsx
+++ b/apps/web/src/pages/weight/AddWeightPage.tsx
@@ -53,21 +53,19 @@ export function AddWeightPage() {
               value={date}
             />
           </Label>
-          <Label text='Weight (kg)'>
-            <NumberInput
-              max={300}
-              min={30}
-              onValueChange={setWeightKg}
-              placeholder='e.g. 78.4'
-              required
-              stepperStep={0.1}
-              value={weightKg}
-            />
-          </Label>
-          <div className={css.formActions}>
-            <Btn isLink render={<Link to='/weight' />} size='sm' variant='ghost'>
-              Cancel
-            </Btn>
+          <div className={css.weightEntry}>
+            <Label text='Weight (kg)'>
+              <NumberInput
+                enterKeyHint='done'
+                max={300}
+                min={30}
+                onValueChange={setWeightKg}
+                placeholder='e.g. 78.4'
+                required
+                stepperStep={0.1}
+                value={weightKg}
+              />
+            </Label>
             <Btn
               disabled={!date || weightKg === null}
               loading={mutation.isPending}
@@ -75,6 +73,11 @@ export function AddWeightPage() {
               type='submit'
             >
               Save entry
+            </Btn>
+          </div>
+          <div className={css.formActions}>
+            <Btn isLink render={<Link to='/weight' />} size='sm' variant='ghost'>
+              Cancel
             </Btn>
           </div>
         </TypedForm>

--- a/apps/web/src/pages/weight/WeightEntryPages.module.css
+++ b/apps/web/src/pages/weight/WeightEntryPages.module.css
@@ -30,9 +30,16 @@
   gap: var(--space-md);
 }
 
+.weightEntry {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: var(--space-xs);
+}
+
 .formActions {
   display: flex;
-  justify-content: flex-end;
+  justify-content: flex-start;
   gap: var(--space-xs);
 }
 

--- a/apps/web/src/pages/weight/WeightPage.tsx
+++ b/apps/web/src/pages/weight/WeightPage.tsx
@@ -121,6 +121,7 @@ function WeightForm({ isSaving, onChange, onSubmit, value }: WeightFormProps) {
       <label className={css.captureField}>
         <span>Today&apos;s weight</span>
         <NumberInput
+          enterKeyHint='done'
           aria-label="Today's weight in kilograms"
           className={css.weightInput}
           inputClassName={css.weightInputField}


### PR DESCRIPTION
## Changes
- place Save entry beside the weight input on the dated weight form
- show the mobile Done key for both weight-entry flows
- leave multi-field numeric forms unchanged so they do not imply premature submission

## Verification
- pnpm --filter @veles/web typecheck
- pnpm check:fix