### PR TITLE
feat: start Google sign-in on login

### DIFF
--- a/apps/web/src/pages/login/LoginPage.tsx
+++ b/apps/web/src/pages/login/LoginPage.tsx
@@ -1,4 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
 import { AuthCard } from './AuthCard';
 import { signIn } from '@/lib/auth/client';
 import { sessionUserQueryKey } from '@/lib/auth/session.query';
@@ -19,24 +20,36 @@ export function LoginPendingPage() {
 export function LoginPage({ redirect }: { redirect?: string }) {
   const { busy, error, runAuthAction } = useAuthAction();
   const queryClient = useQueryClient();
+  const autoSignInStartedRef = useRef(false);
+
+  async function handleGoogleSignIn() {
+    await runAuthAction(async () => {
+      const result = await signIn.social({
+        provider: 'google',
+        callbackURL: getSafeRedirectPath(redirect),
+      });
+
+      if (!result.error) {
+        queryClient.removeQueries({ queryKey: sessionUserQueryKey });
+      }
+    }, 'Google sign-in failed');
+  }
+
+  useEffect(() => {
+    if (autoSignInStartedRef.current) {
+      return;
+    }
+
+    autoSignInStartedRef.current = true;
+    void handleGoogleSignIn();
+  }, []);
 
   return (
     <AuthCard
       busy={busy}
       description='Continue with an invited Google account.'
       error={error}
-      onGoogle={async () => {
-        await runAuthAction(async () => {
-          const result = await signIn.social({
-            provider: 'google',
-            callbackURL: getSafeRedirectPath(redirect),
-          });
-
-          if (!result.error) {
-            queryClient.removeQueries({ queryKey: sessionUserQueryKey });
-          }
-        }, 'Google sign-in failed');
-      }}
+      onGoogle={handleGoogleSignIn}
       title='Sign in'
     />
   );


### PR DESCRIPTION
Automatically starts the existing Google sign-in action when LoginPage mounts, while retaining the button for retry after an error.

Checks: pnpm check:fix