### PR TITLE
fix: improve ghost danger hover contrast

### DIFF
--- a/apps/web/src/components/ui/btn/Btn.module.css
+++ b/apps/web/src/components/ui/btn/Btn.module.css
@@ -108,7 +108,7 @@
 
 .ghostDanger {
   --btn-bg: transparent;
-  --btn-bg-hover: color-mix(in srgb, var(--c-danger-surface) 58%, transparent);
+  --btn-bg-hover: var(--c-danger-surface);
   --btn-border: transparent;
   --btn-border-hover: transparent;
   --btn-color: var(--c-danger-text);


### PR DESCRIPTION
## Proposal

Make the ghost danger button use the established danger surface directly on hover instead of blending it down to 58% opacity. This keeps the ghost state transparent while making the destructive hover affordance visible against the dark page surface.

## Verification

- `pnpm check:fix`
- 19 test files passed, 56 tests passed

No browser smoke test was run per repository instructions.